### PR TITLE
Rebalance food

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 ### Changes since the last release
 
+ * Scale down food production to realistic levels, and make it dependent on CO2 (madman2003)
+ ** Every kerbal now requires 2x Kerbalism greenhouse, or 3x 2.5m SSPX greenhouses, or 6x 3.5m SSPX greenhouses for permanent food production
+ ** SSPX greenhouses include a habitat area, leaving very little space for food production
+ * Kerbalism CO2 tanks are now full by default in order to supply Greenhouses with CO2 (madman2003)
+ * Fix display of Habitat volume and space in tooltip, they used to be swapped (madman2003)
+ * Minor fixes to SSPX config file (madman2003)
+ * Add Electrolysis with H2 priority and Sabatier with H2O priority (madman2003)
+ * Give Greenhouses the basic resources needed to run (madman2003)
  * There is now a help file on GitHub for those wishing to report bugs or contribute to Kerbalism.
    see [CONTRIBUTING.md](https://github.com/MoreRobustThanYou/Kerbalism/blob/master/CONTRIBUTING.md)
  

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -890,6 +890,14 @@ Profile
     maxAmount = 10000
   }
 
+  // To support the pressure control
+  RESOURCE
+  {
+    name = Nitrogen
+    amount = 10000
+    maxAmount = 10000
+  }
+
   RESOURCE
   {
     name = Water

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -875,6 +875,13 @@ Profile
     amount = 10000
     maxAmount = 10000
   }
+
+  RESOURCE
+  {
+    name = Water
+    amount = 1500
+    maxAmount = 1500
+  }
 }
 
 

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -789,7 +789,7 @@ Profile
     // Harvest time is 200 days, but in order to avoid micromanagement this greenhouse supports 0.5 Kerbal for 210 days.
     // Kerbals need 1258 food per 200 days, converted to 210 days that is 1320.9 food.
     crop_size = 660.45                  // amount of resource produced by harvests
-    crop_rate = 0.00000023148           // growth per 4 seconds when all conditions apply, a fully grown crop equals value of 1.0
+    crop_rate = 0.00000023148           // growth per second when all conditions apply, a fully grown crop equals value of 1.0
     ec_rate = 2.5                       // EC/s consumed by the lamp at max intensity
 
     light_tolerance = 400.0             // minimum lighting flux required for growth, in W/m^2
@@ -803,7 +803,7 @@ Profile
     INPUT_RESOURCE
     {
       name = Ammonia
-      rate = 0.00229                    // 15 units required per unit of crop, i.e. 200 days * 900 "4 seconds" per hour * 24 hours * rate == 15 * crop_size
+      rate = 0.00229                    // 15 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 15 * crop_size
     }
 
     // Photosynthesis reaction: 2xH20 + CO2 -> O2 + CH20 + H20
@@ -811,7 +811,7 @@ Profile
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.0000765                  // 0.5 units required per unit of crop, i.e. 200 days * 900 "4 seconds" per hour * 24 hours * rate == 0.5 * crop_size
+      rate = 0.0000765                  // 0.5 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 0.5 * crop_size
     }
 
     INPUT_RESOURCE

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -770,8 +770,16 @@ Profile
     name = Greenhouse
 
     crop_resource = Food                // name of resource produced by harvests
-    crop_size = 2500.0                  // amount of resource produced by harvests
-    crop_rate = 0.00000023148           // growth per-second when all conditions apply
+    // Based on design targets from Prototype Lunar Greenhouse (see https://www.ag.arizona.edu/lunargreenhouse/MidReviews.htm):
+    // Design targets are on slide 18 of https://www.ag.arizona.edu/lunargreenhouse/Documents/2012-07-20_01_Giacomelli.pdf
+    // Prototype Lunar Greenhouse geometry can be found on slide 14 of https://www.ag.arizona.edu/lunargreenhouse/Documents/2012-07-20_01_Giacomelli.pdf
+    // Much larger design for producing food for 6 people can be found here (values not used): https://www.degruyter.com/downloadpdf/j/opag.2017.2.issue-1/opag-2017-0011/opag-2017-0011.pdf
+    // This Greenhouse is assumed to have 20 m^3 volume dedicated to food production (all greenhouses in mod support files are calculated relative to this one).
+    // This Greenhouse is intended to support 0.5 Kerbal just like the Prototype Lunar Greenhouse.
+    // Harvest time is 200 days, but in order to avoid micromanagement this greenhouse supports 0.5 Kerbal for 210 days.
+    // Kerbals need 1258 food per 200 days, converted to 210 days that is 1320.9 food.
+    crop_size = 660.45                  // amount of resource produced by harvests
+    crop_rate = 0.00000023148           // growth per 4 seconds when all conditions apply, a fully grown crop equals value of 1.0
     ec_rate = 2.5                       // EC/s consumed by the lamp at max intensity
 
     light_tolerance = 400.0             // minimum lighting flux required for growth, in W/m^2
@@ -785,19 +793,19 @@ Profile
     INPUT_RESOURCE
     {
       name = Ammonia
-      rate = 0.00695                    // 37530 units required for crop
+      rate = 0.00229                    // 15 units required per unit of crop
     }
 
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.00023148                 // 1250 units required for crop
+      rate = 0.0000765                  // 0.5 units required per unit of crop
     }
 
     OUTPUT_RESOURCE
     {
       name = Oxygen
-      rate = 0.00463                    // 25% of oxygen required by 1 crew member
+      rate = 0.02758                    // 100% of oxygen required by 1 crew member, based on Prototype Lunar Greenhouse design targets (percentage is factor 2 larger than food)
     }
 
     OUTPUT_RESOURCE

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -203,8 +203,8 @@ Profile
     modifier = _WaterRecycler
     input = ElectricCharge@0.0446
     input = WasteWater@0.0001115
-    output = Water@0.0000892
-    output = Waste@0.0000223
+    output = Water@0.0001115
+    output = Waste@0.0000007433 // Waste is 150 times more dense than the density difference between Water and WasteWater
     dump = Waste
   }
 
@@ -216,8 +216,10 @@ Profile
     modifier = _WasteProcessor
     input = ElectricCharge@0.065556
     input = Waste@0.00010926
-    output = Ammonia@0.05463
-    dump = Waste
+    // According to http://ceadserv1.nku.edu/longa/haiti/kids/feces_value.html human waste contains approximately 13% nitrogen based on dry weight
+    // Human waste is considered to the dominant source of Waste
+    // Waste is 975.3 times more dense than Ammonia
+    output = Ammonia@.01385296614
   }
 
   // convention: 1 capacity = enough to compress output of 1 crew member

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -776,7 +776,7 @@ Profile
     // Design targets are on slide 18 of https://www.ag.arizona.edu/lunargreenhouse/Documents/2012-07-20_01_Giacomelli.pdf
     // Prototype Lunar Greenhouse geometry can be found on slide 14 of https://www.ag.arizona.edu/lunargreenhouse/Documents/2012-07-20_01_Giacomelli.pdf
     // Much larger design for producing food for 6 people can be found here (values not used): https://www.degruyter.com/downloadpdf/j/opag.2017.2.issue-1/opag-2017-0011/opag-2017-0011.pdf
-    // This Greenhouse is assumed to have 20 m^3 volume dedicated to food production (all greenhouses in mod support files are calculated relative to this one).
+    // This Greenhouse is assumed to have 24 m^3 volume dedicated to food production (all greenhouses in mod support files are calculated relative to this one).
     // This Greenhouse is intended to support 0.5 Kerbal just like the Prototype Lunar Greenhouse.
     // Harvest time is 200 days, but in order to avoid micromanagement this greenhouse supports 0.5 Kerbal for 210 days.
     // Kerbals need 1258 food per 200 days, converted to 210 days that is 1320.9 food.
@@ -795,7 +795,7 @@ Profile
     INPUT_RESOURCE
     {
       name = Ammonia
-      rate = 0.00229                    // 15 units required per unit of crop
+      rate = 0.00229                    // 15 units required per unit of crop, i.e. 200 days * 900 "4 seconds" per hour * 24 hours * rate == 15 * crop_size
     }
 
     // Photosynthesis reaction: 2xH20 + CO2 -> O2 + CH20 + H20
@@ -803,13 +803,13 @@ Profile
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.0000765                  // 0.5 units required per unit of crop
+      rate = 0.0000765                  // 0.5 units required per unit of crop, i.e. 200 days * 900 "4 seconds" per hour * 24 hours * rate == 0.5 * crop_size
     }
 
     INPUT_RESOURCE
     {
       name = CarbonDioxide              // Plants can work on WasteAtmosphere without a scrubber inbetween, but there is no way to produce WasteAtmosphere right now if a scrubber has converted it all, or if CO2 is the primary source
-      rate = 0.02782                    // Matched to Oxygen output, by comparing the molecular mass ratio, and the density ratio to arrive at rate ratio
+      rate = 0.02782                    // Matched to Oxygen output, by comparing the molecular mass ratio, and the density ratio to arrive at rate ratio, total ratio used is CO2 rate = 1.0088 * O2 rate
     }
 
     OUTPUT_RESOURCE
@@ -821,7 +821,7 @@ Profile
     OUTPUT_RESOURCE
     {
       name = WasteWater
-      rate = 0.00003825                 // Waste is assumed to dissolve into the water, WasteWater has higher density than Water
+      rate = 0.00003825                 // WasteWater is equal to half input Water, Waste is assumed to dissolve into the water, WasteWater has higher density than Water
     }
   }
 

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -796,6 +796,8 @@ Profile
       rate = 0.00229                    // 15 units required per unit of crop
     }
 
+    // Photosynthesis reaction: 2xH20 + CO2 -> O2 + CH20 + H20
+    // Note that CH20 is an intermediate carbohydrate, energy that goes into the food, in the actual food it can be any CxHyOz compound
     INPUT_RESOURCE
     {
       name = Water
@@ -811,7 +813,7 @@ Profile
     OUTPUT_RESOURCE
     {
       name = WasteWater
-      rate = 0.00023033
+      rate = 0.00003825                 // Waste is assumed to dissolve into the water, WasteWater has higher density than Water
     }
   }
 

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -50,6 +50,14 @@ Profile
 
   Supply
   {
+    resource = CarbonDioxide
+    low_message = Carbon dioxide reserves are getting low on $VESSEL@<i></i>
+    empty_message = There is no more carbon dioxide on $VESSEL@<i>The plants onboard have filed a formal complaint</i>
+    refill_message = $VESSEL carbon dioxide reserves restored@<i>The plants onboard are grateful</i>
+  }
+
+  Supply
+  {
     resource = Nitrogen
     low_message = Nitrogen reserves are getting low on $VESSEL
     empty_message = There is no more nitrogen on $VESSEL@<i>Time to go back in the suits</i>

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -307,6 +307,17 @@ Profile
 
   Process
   {
+    name = water electrolysis hydrogen priority
+    modifier = _WaterElectrolysisH2Priority
+    input = ElectricCharge@0.5
+    input = Water@0.0008043014
+    output = Hydrogen@1.0
+    output = Oxygen@0.5065967706
+    dump = Oxygen
+  }
+
+  Process
+  {
     name = waste incinerator
     modifier = _WasteIncinerator
     input = Waste@0.0001082667 // H18C82
@@ -1023,6 +1034,14 @@ Profile
   MODULE
   {
     name = ProcessController
+    resource = _WaterElectrolysisH2Priority
+    title = Water electrolysis hydrogen priority
+    capacity = 1
+  }
+
+  MODULE
+  {
+    name = ProcessController
     resource = _Sabatier
     title = Sabatier process
     capacity = 1
@@ -1129,6 +1148,19 @@ Profile
         type = ProcessController
         id_field = resource
         id_value = _WaterElectrolysisO2Priority
+      }
+    }
+
+    SETUP
+    {
+      name = Water Electrolysis (H2 priority)
+      desc = Split <b>Water</b> into its <b>Hydrogen</b> and <b>Oxygen</b> components. If necessary Oxygen will be vented in order to continue the Hydrogen extraction.
+
+      MODULE
+      {
+        type = ProcessController
+        id_field = resource
+        id_value = _WaterElectrolysisH2Priority
       }
     }
 
@@ -1591,6 +1623,13 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
   name = _WaterElectrolysisO2Priority
+  density = 0.0
+  isVisible = false
+}
+
+RESOURCE_DEFINITION
+{
+  name = _WaterElectrolysisH2Priority
   density = 0.0
   isVisible = false
 }

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -213,9 +213,10 @@ Profile
     modifier = _WaterRecycler
     input = ElectricCharge@0.0446
     input = WasteWater@0.0001115
-    output = Water@0.0001115
-    output = Waste@0.0000007433 // Waste is 150 times more dense than the density difference between Water and WasteWater
-    dump = Waste
+    output = Water@0.0000948 // ISS currently achieves 75% Water recovery from urine, although its design target was 85% (quality of urine is issue), we use the design target to be gentle on our users
+    output = Ammonia@0.000652 // Based on https://en.wikipedia.org/wiki/Urine assume we recover 90% of 0.5% mass percentage of Ammonia, keep in mind Ammonia is far less dense than Water
+    output = CarbonDioxide@0.000257 // Based on https://en.wikipedia.org/wiki/Urine assume we recover 90% of 0.5% mass percentage of CarbonDioxide, keep in mind CO2 is far less dense than Water
+    dump = Ammonia,CarbonDioxide
   }
 
 

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -861,6 +861,17 @@ Profile
     amount = 1000
     maxAmount = 1000
   }
+
+  // CarbonDioxide is provided because humans don't provide enough CO2 for their required food production
+  // Both https://www.space.com/9353-lunar-greenhouse-grow-food-future-moon-colonies.html and
+  // https://www.degruyter.com/downloadpdf/j/opag.2017.2.issue-1/opag-2017-0011/opag-2017-0011.pdf
+  // mention CO2 injection despite being closed loop systems.
+  RESOURCE
+  {
+    name = CarbonDioxide
+    amount = 10000
+    maxAmount = 10000
+  }
 }
 
 

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -785,7 +785,7 @@ Profile
       RESOURCE
       {
         name = CarbonDioxide
-        amount = 0
+        amount = 601.36
         maxAmount = 601.36
         @amount *= #$../../../ContainerVolume$
         @maxAmount *= #$../../../ContainerVolume$

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -170,7 +170,7 @@ Profile
   {
     name = non-regenerative scrubber
     modifier = _NonRegenScrubber
-    input = WasteAtmosphere@0.00004       // capacity start at 2, reach 1 in 6h, then drop below
+    input = WasteAtmosphere@0.04       // capacity start at 2, reach 1 in 6h, then drop below
     input = _NonRegenScrubber@0.000023148 // consume 0.5 capacity in 6h
   }
 
@@ -180,7 +180,7 @@ Profile
     name = scrubber
     modifier = _Scrubber
     input = ElectricCharge@0.025
-    input = WasteAtmosphere@0.00002
+    input = WasteAtmosphere@0.02
     output = CarbonDioxide@0.02
     dump = true
   }
@@ -192,7 +192,7 @@ Profile
     modifier = _PressureControl
     input = ElectricCharge@0.3
     input = Nitrogen@0.35
-    output = Atmosphere@0.00035
+    output = Atmosphere@0.35
     dump = false
   }
 
@@ -237,7 +237,7 @@ Profile
   {
     name = atmo leaks
     modifier = surface,breathable
-    input = Atmosphere@0.000000148
+    input = Atmosphere@0.000148
     // from ISS: 899 m³ volume, 452 m² surface (estimated), 0.227 Kg/day (structural) + 1.543 Kg/day (activities)
   }
 

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -811,10 +811,16 @@ Profile
 
     // In a hydroponic system plants grow in water containing nutrients, the system is assumed to be closed loop.
     // Therefore only the water loss during photosynthesis is modeled.
+
+    // Water efficient foods require around 250-500 L water per kg of crop (see https://www.theguardian.com/news/datablog/2013/jan/10/how-much-water-food-production-waste)
+    // In a regerative system (see https://www.ag.arizona.edu/lunargreenhouse/Documents/2012-07-20_01_Giacomelli.pdf slide 19) water is also produced.
+    // In this example that reduces effective consumption from 357 L/kg to 72 L/kg.
+    // 1 unit of Food has a mass 0.28 kg (see community resource pack), therefore we will use 72 L/kg * 0.28 kg = 20 L of Water
+    // 1 unit of Water matches 1 L, so we need 20 units of Water per unit of Food.
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.00003825                 // 0.5 units required per unit of crop, of which only half is lost during photosynthesis, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 0.25 * crop_size
+      rate = 0.00306                    // 20 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 20 * crop_size
     }
 
     INPUT_RESOURCE

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -828,13 +828,16 @@ Profile
 
     // Water efficient foods require around 250-500 L water per kg of crop (see https://www.theguardian.com/news/datablog/2013/jan/10/how-much-water-food-production-waste)
     // In a regerative system (see https://www.ag.arizona.edu/lunargreenhouse/Documents/2012-07-20_01_Giacomelli.pdf slide 19) water is also produced.
-    // In this example that reduces effective consumption from 357 L/kg to 72 L/kg.
-    // 1 unit of Food has a mass 0.28 kg (see community resource pack), therefore we will use 72 L/kg * 0.28 kg = 20 L of Water
-    // 1 unit of Water matches 1 L, so we need 20 units of Water per unit of Food.
+    // In this example effective water consumption is 4.3 L per day. Every day approximately 2.4 kg of biomass is produced (not all of which can be eaten).
+    // In this example the effective water consumption per kg of biomass is 1.8 L/kg.
+    // TODO: Figure out what percentage of biomass actually becomes Food.
+    // TODO: Figure how to recover the non-eatable biosmass.
+    // 1 unit of Food has a mass 0.28 kg (see community resource pack), therefore we will use 1.8 L/kg * 0.28 kg = 0.5 L of Water
+    // 1 unit of Water matches 1 L, so we need 0.5 units of Water per unit of Food.
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.00306                    // 20 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 20 * crop_size
+      rate = 0.0000764                  // 0.5 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 0.5 * crop_size
     }
 
     INPUT_RESOURCE

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -804,6 +804,12 @@ Profile
       rate = 0.0000765                  // 0.5 units required per unit of crop
     }
 
+    INPUT_RESOURCE
+    {
+      name = CarbonDioxide              // Plants can work on WasteAtmosphere without a scrubber inbetween, but there is no way to produce WasteAtmosphere right now if a scrubber has converted it all, or if CO2 is the primary source
+      rate = 0.02782                    // Matched to Oxygen output, by comparing the molecular mass ratio, and the density ratio to arrive at rate ratio
+    }
+
     OUTPUT_RESOURCE
     {
       name = Oxygen

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -227,10 +227,10 @@ Profile
     modifier = _WasteProcessor
     input = ElectricCharge@0.065556
     input = Waste@0.00010926
-    // According to http://ceadserv1.nku.edu/longa/haiti/kids/feces_value.html human waste contains approximately 13% nitrogen based on dry weight
-    // Human waste is considered to the dominant source of Waste
+    // According to https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4500995/ feces contains approximately 0.7% nitrogen.
+    // Feces is considered to the dominant source of Waste
     // Waste is 975.3 times more dense than Ammonia
-    output = Ammonia@.01385296614
+    output = Ammonia@0.000746
   }
 
   // convention: 1 capacity = enough to compress output of 1 crew member

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -806,8 +806,8 @@ Profile
       rate = 0.00229                    // 15 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 15 * crop_size
     }
 
-    // Photosynthesis reaction: 2xH20 + CO2 -> O2 + CH20 + H20
-    // Note that CH20 is an intermediate carbohydrate, energy that goes into the food, in the actual food it can be any CxHyOz compound
+    // Photosynthesis reaction: 2xH2O + CO2 -> O2 + CH2O + H2O
+    // Note that CH2O is an intermediate carbohydrate, energy that goes into the food, in the actual food it can be any CxHyOz compound
     INPUT_RESOURCE
     {
       name = Water

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -808,10 +808,13 @@ Profile
 
     // Photosynthesis reaction: 2xH2O + CO2 -> O2 + CH2O + H2O
     // Note that CH2O is an intermediate carbohydrate, energy that goes into the food, in the actual food it can be any CxHyOz compound
+
+    // In a hydroponic system plants grow in water containing nutrients, the system is assumed to be closed loop.
+    // Therefore only the water loss during photosynthesis is modeled.
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.0000765                  // 0.5 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 0.5 * crop_size
+      rate = 0.00003825                 // 0.5 units required per unit of crop, of which only half is lost during photosynthesis, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 0.25 * crop_size
     }
 
     INPUT_RESOURCE
@@ -824,12 +827,6 @@ Profile
     {
       name = Oxygen
       rate = 0.02758                    // 100% of oxygen required by 1 crew member, based on Prototype Lunar Greenhouse design targets (percentage is factor 2 larger than food)
-    }
-
-    OUTPUT_RESOURCE
-    {
-      name = WasteWater
-      rate = 0.00003825                 // WasteWater is equal to half input Water, Waste is assumed to dissolve into the water, WasteWater has higher density than Water
     }
   }
 

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -113,6 +113,7 @@ Profile
     input = Water
     output = WasteWater
     rate = 0.605 // 2.42 Kg per-day
+    ratio = 1.000 // Every unit of Water becomes a unit of WasteWater, extra mass comes from inside body
     interval = 5400.0 // 4 drinks per-day
     degeneration = 0.08333 // 12 drinks, 3 days
     warning_message = $ON_VESSEL$KERBAL is thirsty
@@ -127,6 +128,7 @@ Profile
     input = Oxygen
     output = WasteAtmosphere
     rate = 0.02758 // 0.84 Kg per-day
+    ratio = 1.0088 // By comparing the molecular mass ratio, and the density ratio to arrive at rate ratio, total ratio used is CO2 rate = 1.0088 * O2 rate
     degeneration = 0.0055555 // 3 minutes
     modifier = breathable
     warning_message = $ON_VESSEL$KERBAL can't breathe

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -905,8 +905,8 @@ Profile
   RESOURCE
   {
     name = Water
-    amount = 1500
-    maxAmount = 1500
+    amount = 50
+    maxAmount = 50
   }
 }
 

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -330,6 +330,18 @@ Profile
 
   Process
   {
+    name = sabatier process water priority
+    modifier = _SabatierH2OPriority
+    input = ElectricCharge@0.5
+    input = CarbonDioxide@0.2514920085
+    input = Hydrogen@1.0
+    output = Water@0.0004017039
+    output = LiquidFuel@0.0001788570195417 // (Methane@0.2494519101)
+    dump = LiquidFuel
+  }
+
+  Process
+  {
     name = haber process
     modifier = _Haber
     input = Nitrogen@0.3328758387
@@ -1007,6 +1019,14 @@ Profile
   MODULE
   {
     name = ProcessController
+    resource = _SabatierH2OPriority
+    title = Sabatier process water priority
+    capacity = 1
+  }
+
+  MODULE
+  {
+    name = ProcessController
     resource = _Haber
     title = Haber process
     capacity = 1
@@ -1102,14 +1122,27 @@ Profile
 
     SETUP
     {
-      name = Sabatier Process
-      desc = <b>Hydrogen</b> and <b>CarbonDioxide</b> react with a nickel catalyst to produce <b>Water</b> and <b>LiquidFuel</b>.
+      name = Sabatier Process (LF priority)
+      desc = <b>Hydrogen</b> and <b>CarbonDioxide</b> react with a nickel catalyst to produce <b>Water</b> and <b>LiquidFuel</b>. If needed Water will be vented in order to continue the LiquidFuel extraction.
 
       MODULE
       {
         type = ProcessController
         id_field = resource
         id_value = _Sabatier
+      }
+    }
+
+    SETUP
+    {
+      name = Sabatier Process (H2O priority)
+      desc = <b>Hydrogen</b> and <b>CarbonDioxide</b> react with a nickel catalyst to produce <b>Water</b> and <b>LiquidFuel</b>. If needed LiquidFuel will be vented in order to continue the Water extraction.
+
+      MODULE
+      {
+        type = ProcessController
+        id_field = resource
+        id_value = _SabatierH2OPriority
       }
     }
 
@@ -1553,6 +1586,13 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
   name = _Sabatier
+  density = 0.0
+  isVisible = false
+}
+
+RESOURCE_DEFINITION
+{
+  name = _SabatierH2OPriority
   density = 0.0
   isVisible = false
 }

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -98,6 +98,14 @@
 		surface = 4.91
 	}
 }
+@PART[sspx-aquaculture-375-1]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
+{
+	@MODULE[Habitat]
+	{
+		volume = 18
+		surface = 8
+	}
+}
 // end
 
 // Stock-alike Station Parts Expansion Redux

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -382,13 +382,13 @@
     INPUT_RESOURCE
     {
       name = Ammonia
-      rate = .00151                     // 15 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 15 * crop_size
+      rate = 0.00151                    // 15 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 15 * crop_size
     }
 
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.00202                    // 20 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 20 * crop_size
+      rate = 0.0000505                  // 0.5 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 0.5 * crop_size
     }
 
     INPUT_RESOURCE
@@ -465,7 +465,7 @@
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.00116                    // 20 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 20 * crop_size
+      rate = 0.0000290                  // 0.5 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 0.5 * crop_size
     }
 
     INPUT_RESOURCE

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -399,7 +399,7 @@
     OUTPUT_RESOURCE
     {
       name = WasteWater
-      rate = 0.000391561
+      rate = 0.0000191                  // Waste is assumed to dissolve into the water, WasteWater has higher density than Water
     }
   }
   
@@ -477,7 +477,7 @@
     OUTPUT_RESOURCE
     {
       name = WasteWater
-      rate = 0.0005873415
+      rate = 0.00000382                 // Waste is assumed to dissolve into the water, WasteWater has higher density than Water
     }
   }
   

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -26,7 +26,7 @@
 // region Habitats
 // by schrema
 // ============================================================================
-@PART[crewtube-airlock-25]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
+@PART[sspx-airlock-25-1]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{
@@ -34,7 +34,7 @@
 		surface = 7.8
 	}
 }
-@PART[crewpod-observation-25]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
+@PART[sspx-observation-25-1]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{
@@ -42,7 +42,7 @@
 		surface = 32.42
 	}
 }
-@PART[crewpod-habitation-375]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
+@PART[sspx-habitation-375-*]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{
@@ -50,7 +50,7 @@
 		surface = 23.56
 	}
 }
-@PART[crewtube-25-375-1]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
+@PART[sspx-tube-375-*]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{
@@ -58,7 +58,7 @@
 		surface = 13.09
 	}
 }
-@PART[crewpod-habitation-25]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
+@PART[sspx-habitation-25-*]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{
@@ -66,7 +66,7 @@
 		surface = 36.32
 	}
 }
-@PART[crewtube-airlock-125]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
+@PART[sspx-airlock-125-1]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{
@@ -74,7 +74,7 @@
 		surface = 4.17
 	}
 }
-@PART[crewpod-cupola-375]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
+@PART[sspx-cupola-375-1]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{
@@ -82,7 +82,7 @@
 		surface = 18.57
 	}
 }
-@PART[crewpod-greenhouse-25]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
+@PART[sspx-greenhouse-25-1]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{
@@ -90,7 +90,7 @@
 		surface = 5.30
 	}
 }
-@PART[crewpod-greenhouse-375]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
+@PART[sspx-greenhouse-375-1]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -403,7 +403,7 @@
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.0000253                  // 0.5 units required per unit of crop, of which only half is lost during photosynthesis, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 0.25 * crop_size
+      rate = 0.00202                    // 20 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 20 * crop_size
     }
 
     INPUT_RESOURCE
@@ -488,7 +488,7 @@
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.0000145                  // 0.5 units required per unit of crop, of which only half is lost during photosynthesis, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 0.25 * crop_size
+      rate = 0.00116                    // 20 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 20 * crop_size
     }
 
     INPUT_RESOURCE

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -383,7 +383,7 @@
     // This greenhouse is assumed to have a volume of 25 m^3, 9 m^3 habitat on the inside
     // and 16 m^3 food production on the outside. It will therefore support 0.33 Kerbals.
     crop_size = 435.90                  // amount of resource produced by harvests
-    crop_rate = 0.00000023148           // growth per 4 seconds when all conditions apply, a fully grown crop equals value of 1.0
+    crop_rate = 0.00000023148           // growth per second when all conditions apply, a fully grown crop equals value of 1.0
     ec_rate = 1.7                       // EC/s consumed by the lamp at max intensity
 
     light_tolerance = 400.0             // minimum lighting flux required for growth, in W/m^2
@@ -397,13 +397,13 @@
     INPUT_RESOURCE
     {
       name = Ammonia
-      rate = .00151                     // 15 units required per unit of crop, i.e. 200 days * 900 "4 seconds" per hour * 24 hours * rate == 15 * crop_size
+      rate = .00151                     // 15 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 15 * crop_size
     }
 
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.0000505                  // 0.5 units required per unit of crop, i.e. 200 days * 900 "4 seconds" per hour * 24 hours * rate == 0.5 * crop_size
+      rate = 0.0000505                  // 0.5 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 0.5 * crop_size
     }
 
     INPUT_RESOURCE
@@ -474,7 +474,7 @@
     // This greenhouse is assumed to have a volume of 19 m^3, 10 m^3 habitat on the inside
     // and 9 m^3 food production on the outside. It will therefore support 0.19 Kerbals.
     crop_size = 250.97                  // amount of resource produced by harvests
-    crop_rate = 0.00000023148           // growth per 4 seconds when all conditions apply, a fully grown crop equals value of 1.0
+    crop_rate = 0.00000023148           // growth per second when all conditions apply, a fully grown crop equals value of 1.0
     ec_rate = 1.0                       // EC/s consumed by the lamp at max intensity
 
     light_tolerance = 400.0             // minimum lighting flux required for growth, in W/m^2
@@ -488,13 +488,13 @@
     INPUT_RESOURCE
     {
       name = Ammonia
-      rate = 0.000871                   // 15 units required per unit of crop, i.e. 200 days * 900 "4 seconds" per hour * 24 hours * rate == 15 * crop_size
+      rate = 0.000871                   // 15 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 15 * crop_size
     }
 
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.0000290                  // 0.5 units required per unit of crop, i.e. 200 days * 900 "4 seconds" per hour * 24 hours * rate == 0.5 * crop_size
+      rate = 0.0000290                  // 0.5 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 0.5 * crop_size
     }
 
     INPUT_RESOURCE

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -439,6 +439,13 @@
     amount = 7000
     maxAmount = 7000
   }
+
+  RESOURCE
+  {
+    name = Water
+    amount = 950
+    maxAmount = 950
+  }
 }
 
 
@@ -523,6 +530,13 @@
     name = CarbonDioxide
     amount = 4000
     maxAmount = 4000
+  }
+
+  RESOURCE
+  {
+    name = Water
+    amount = 600
+    maxAmount = 600
   }
 }
 

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -403,7 +403,7 @@
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.0000505                  // 0.5 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 0.5 * crop_size
+      rate = 0.0000253                  // 0.5 units required per unit of crop, of which only half is lost during photosynthesis, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 0.25 * crop_size
     }
 
     INPUT_RESOURCE
@@ -416,12 +416,6 @@
     {
       name = Oxygen
       rate = 0.0182                     // 66% of oxygen required by 1 crew member
-    }
-
-    OUTPUT_RESOURCE
-    {
-      name = WasteWater
-      rate = 0.0000253                  // WasteWater is equal to half input Water, Waste is assumed to dissolve into the water, WasteWater has higher density than Water
     }
   }
   
@@ -494,7 +488,7 @@
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.0000290                  // 0.5 units required per unit of crop, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 0.5 * crop_size
+      rate = 0.0000145                  // 0.5 units required per unit of crop, of which only half is lost during photosynthesis, i.e. 200 days * 3600 seconds per hour * 6 hours * rate == 0.25 * crop_size
     }
 
     INPUT_RESOURCE
@@ -507,12 +501,6 @@
     {
       name = Oxygen
       rate = 0.0105                     // 38% of oxygen required by 1 crew member
-    }
-
-    OUTPUT_RESOURCE
-    {
-      name = WasteWater
-      rate = 0.0000145                  // WasteWater is equal to half input Water, Waste is assumed to dissolve into the water, WasteWater has higher density than Water
     }
   }
   

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -428,8 +428,8 @@
   RESOURCE
   {
     name = Water
-    amount = 950
-    maxAmount = 950
+    amount = 30
+    maxAmount = 30
   }
 }
 
@@ -505,8 +505,8 @@
   RESOURCE
   {
     name = Water
-    amount = 600
-    maxAmount = 600
+    amount = 20
+    maxAmount = 20
   }
 }
 

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -390,6 +390,12 @@
       rate = 0.0000382                  // 0.5 units required per unit of crop
     }
 
+    INPUT_RESOURCE
+    {
+      name = CarbonDioxide
+      rate = 0.0139                     // Matched to Oxygen output, by comparing the molecular mass ratio, and the density ratio to arrive at rate ratio
+    }
+
     OUTPUT_RESOURCE
     {
       name = Oxygen
@@ -451,8 +457,8 @@
     light_tolerance = 400.0             // minimum lighting flux required for growth, in W/m^2
     pressure_tolerance = 0.1            // minimum pressure required for growth, in sea level atmospheres
     radiation_tolerance = 0.000008333   // maximum radiation allowed for growth in rad/s, considered after shielding is applied
-	
-    lamps =   			                // object with emissive texture used to represent lamp intensity graphically
+
+    lamps =                             // object with emissive texture used to represent lamp intensity graphically
     shutters =                          // animation to manipulate shutters
     plants =                            // animation to represent plant growth graphically
 
@@ -466,6 +472,12 @@
     {
       name = Water
       rate = 0.00000764                 // 0.5 units required per unit of crop
+    }
+
+    INPUT_RESOURCE
+    {
+      name = CarbonDioxide
+      rate = 0.00557                    // Matched to Oxygen output, by comparing the molecular mass ratio, and the density ratio to arrive at rate ratio
     }
 
     OUTPUT_RESOURCE

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -363,34 +363,37 @@
     name = Greenhouse
 
     crop_resource = Food                // name of resource produced by harvests
-    crop_size = 4250.0                  // amount of resource produced by harvests
-    crop_rate = 0.00000023148           // growth per-second when all conditions apply
+    // Greenhouse is scaled relative to Kerbalism Greenhouse, see comments of that one.
+    // This greenhouse is assumed to have a volume of 25 m^3, 15 m^3 habitat on the inside
+    // and 10 m^3 food production on the outside. It will therefore support 0.25 Kerbals.
+    crop_size = 333.23                  // amount of resource produced by harvests
+    crop_rate = 0.00000023148           // growth per 4 seconds when all conditions apply, a fully grown crop equals value of 1.0
     ec_rate = 4.25                      // EC/s consumed by the lamp at max intensity
 
     light_tolerance = 400.0             // minimum lighting flux required for growth, in W/m^2
     pressure_tolerance = 0.1            // minimum pressure required for growth, in sea level atmospheres
     radiation_tolerance = 0.000008333   // maximum radiation allowed for growth in rad/s, considered after shielding is applied
-	
-    lamps =  							// object with emissive texture used to represent lamp intensity graphically
-    shutters = 25DoorsOpen                     // animation to manipulate shutters
+
+    lamps =                             // object with emissive texture used to represent lamp intensity graphically
+    shutters = 25DoorsOpen              // animation to manipulate shutters
     plants =                            // animation to represent plant growth graphically
 
     INPUT_RESOURCE
     {
       name = Ammonia
-      rate = 0.011815                   // 63800 units required for crop
+      rate = 0.00115                    // 15 units required per unit of crop
     }
 
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.000393516                // 2125 units required for crop
+      rate = 0.0000382                  // 0.5 units required per unit of crop
     }
 
     OUTPUT_RESOURCE
     {
       name = Oxygen
-      rate = 0.007871                   // 42.5% of oxygen required by 1 crew member
+      rate = 0.0138                     // 50% of oxygen required by 1 crew member
     }
 
     OUTPUT_RESOURCE
@@ -438,8 +441,11 @@
     name = Greenhouse
 
     crop_resource = Food                // name of resource produced by harvests
-    crop_size = 6375.0                  // amount of resource produced by harvests
-    crop_rate = 0.00000023148           // growth per-second when all conditions apply
+    // Greenhouse is scaled relative to Kerbalism Greenhouse, see comments of that one.
+    // This greenhouse is assumed to have a volume of 21 m^3, 15 m^3 habitat on the inside
+    // and 4 m^3 food production on the outside. It will therefore support 0.10 Kerbals.
+    crop_size = 132.09                  // amount of resource produced by harvests
+    crop_rate = 0.00000023148           // growth per 4 seconds when all conditions apply, a fully grown crop equals value of 1.0
     ec_rate = 6.375                     // EC/s consumed by the lamp at max intensity
 
     light_tolerance = 400.0             // minimum lighting flux required for growth, in W/m^2
@@ -453,19 +459,19 @@
     INPUT_RESOURCE
     {
       name = Ammonia
-      rate = 0.0177225                  // 95700 units required for crop
+      rate = 0.000229                   // 15 units required per unit of crop
     }
 
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.000590274                // 3190 units required for crop
+      rate = 0.00000764                 // 0.5 units required per unit of crop
     }
 
     OUTPUT_RESOURCE
     {
       name = Oxygen
-      rate = 0.0118065                  // 64% of oxygen required by 1 crew member
+      rate = 0.00552                    // 20% of oxygen required by 1 crew member
     }
 
     OUTPUT_RESOURCE

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -82,6 +82,22 @@
 		surface = 18.57
 	}
 }
+@PART[crewpod-greenhouse-25]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
+{
+	@MODULE[Habitat]
+	{
+		volume = 8.83
+		surface = 5.30
+	}
+}
+@PART[crewpod-greenhouse-375]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
+{
+	@MODULE[Habitat]
+	{
+		volume = 9.81
+		surface = 4.91
+	}
+}
 // end
 
 // Stock-alike Station Parts Expansion Redux

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -3,7 +3,7 @@
 // ============================================================================
 // region Comfort providers
 // ============================================================================
-@PART[crewpod-observation-25|crewpod-cupola-375]:NEEDS[StationPartsExpansion,FeatureComfort]:FOR[Kerbalism]
+@PART[sspx-observation-25-1|sspx-cupola-375-1]:NEEDS[StationPartsExpansion,FeatureComfort]:FOR[Kerbalism]
 {
   MODULE
   {

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -361,21 +361,6 @@
 {
   MODULE
   {
-    name = Habitat
-    toggle = false
-  }
-
-  MODULE
-  {
-    name = ProcessController
-    resource = _PressureControl
-    title = Pressure control
-    capacity = 0.2143
-    running = true
-  }
-
-  MODULE
-  {
     name = Greenhouse
 
     crop_resource = Food                // name of resource produced by harvests
@@ -451,21 +436,6 @@
 
 @PART[sspx-greenhouse-375-1]:NEEDS[ProfileDefault]:FOR[Kerbalism]
 {
-  MODULE
-  {
-    name = Habitat
-    toggle = false
-  }
-
-  MODULE
-  {
-    name = ProcessController
-    resource = _PressureControl
-    title = Pressure control
-    capacity = 0.2143
-    running = true
-  }
-
   MODULE
   {
     name = Greenhouse

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -384,7 +384,7 @@
     // and 16 m^3 food production on the outside. It will therefore support 0.33 Kerbals.
     crop_size = 435.90                  // amount of resource produced by harvests
     crop_rate = 0.00000023148           // growth per 4 seconds when all conditions apply, a fully grown crop equals value of 1.0
-    ec_rate = 4.25                      // EC/s consumed by the lamp at max intensity
+    ec_rate = 1.7                       // EC/s consumed by the lamp at max intensity
 
     light_tolerance = 400.0             // minimum lighting flux required for growth, in W/m^2
     pressure_tolerance = 0.1            // minimum pressure required for growth, in sea level atmospheres
@@ -468,7 +468,7 @@
     // and 9 m^3 food production on the outside. It will therefore support 0.19 Kerbals.
     crop_size = 250.97                  // amount of resource produced by harvests
     crop_rate = 0.00000023148           // growth per 4 seconds when all conditions apply, a fully grown crop equals value of 1.0
-    ec_rate = 6.375                     // EC/s consumed by the lamp at max intensity
+    ec_rate = 1.0                       // EC/s consumed by the lamp at max intensity
 
     light_tolerance = 400.0             // minimum lighting flux required for growth, in W/m^2
     pressure_tolerance = 0.1            // minimum pressure required for growth, in sea level atmospheres

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -435,8 +435,15 @@
   RESOURCE
   {
     name = Ammonia
-    amount = 1700
-    maxAmount = 1700
+    amount = 700
+    maxAmount = 700
+  }
+
+  RESOURCE
+  {
+    name = CarbonDioxide
+    amount = 7000
+    maxAmount = 7000
   }
 }
 
@@ -519,8 +526,15 @@
   RESOURCE
   {
     name = Ammonia
-    amount = 2550
-    maxAmount = 2550
+    amount = 400
+    maxAmount = 400
+  }
+
+  RESOURCE
+  {
+    name = CarbonDioxide
+    amount = 4000
+    maxAmount = 4000
   }
 }
 

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -380,9 +380,9 @@
 
     crop_resource = Food                // name of resource produced by harvests
     // Greenhouse is scaled relative to Kerbalism Greenhouse, see comments of that one.
-    // This greenhouse is assumed to have a volume of 25 m^3, 15 m^3 habitat on the inside
-    // and 10 m^3 food production on the outside. It will therefore support 0.25 Kerbals.
-    crop_size = 333.23                  // amount of resource produced by harvests
+    // This greenhouse is assumed to have a volume of 25 m^3, 9 m^3 habitat on the inside
+    // and 16 m^3 food production on the outside. It will therefore support 0.33 Kerbals.
+    crop_size = 435.90                  // amount of resource produced by harvests
     crop_rate = 0.00000023148           // growth per 4 seconds when all conditions apply, a fully grown crop equals value of 1.0
     ec_rate = 4.25                      // EC/s consumed by the lamp at max intensity
 
@@ -397,31 +397,31 @@
     INPUT_RESOURCE
     {
       name = Ammonia
-      rate = 0.00115                    // 15 units required per unit of crop
+      rate = .00151                     // 15 units required per unit of crop, i.e. 200 days * 900 "4 seconds" per hour * 24 hours * rate == 15 * crop_size
     }
 
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.0000382                  // 0.5 units required per unit of crop
+      rate = 0.0000505                  // 0.5 units required per unit of crop, i.e. 200 days * 900 "4 seconds" per hour * 24 hours * rate == 0.5 * crop_size
     }
 
     INPUT_RESOURCE
     {
       name = CarbonDioxide
-      rate = 0.0139                     // Matched to Oxygen output, by comparing the molecular mass ratio, and the density ratio to arrive at rate ratio
+      rate = 0.0184                     // Matched to Oxygen output, by comparing the molecular mass ratio, and the density ratio to arrive at rate ratio, total ratio used is CO2 rate = 1.0088 * O2 rate
     }
 
     OUTPUT_RESOURCE
     {
       name = Oxygen
-      rate = 0.0138                     // 50% of oxygen required by 1 crew member
+      rate = 0.0182                     // 66% of oxygen required by 1 crew member
     }
 
     OUTPUT_RESOURCE
     {
       name = WasteWater
-      rate = 0.0000191                  // Waste is assumed to dissolve into the water, WasteWater has higher density than Water
+      rate = 0.0000253                  // WasteWater is equal to half input Water, Waste is assumed to dissolve into the water, WasteWater has higher density than Water
     }
   }
   
@@ -464,9 +464,9 @@
 
     crop_resource = Food                // name of resource produced by harvests
     // Greenhouse is scaled relative to Kerbalism Greenhouse, see comments of that one.
-    // This greenhouse is assumed to have a volume of 21 m^3, 15 m^3 habitat on the inside
-    // and 4 m^3 food production on the outside. It will therefore support 0.10 Kerbals.
-    crop_size = 132.09                  // amount of resource produced by harvests
+    // This greenhouse is assumed to have a volume of 19 m^3, 10 m^3 habitat on the inside
+    // and 9 m^3 food production on the outside. It will therefore support 0.19 Kerbals.
+    crop_size = 250.97                  // amount of resource produced by harvests
     crop_rate = 0.00000023148           // growth per 4 seconds when all conditions apply, a fully grown crop equals value of 1.0
     ec_rate = 6.375                     // EC/s consumed by the lamp at max intensity
 
@@ -481,31 +481,31 @@
     INPUT_RESOURCE
     {
       name = Ammonia
-      rate = 0.000229                   // 15 units required per unit of crop
+      rate = 0.000871                   // 15 units required per unit of crop, i.e. 200 days * 900 "4 seconds" per hour * 24 hours * rate == 15 * crop_size
     }
 
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.00000764                 // 0.5 units required per unit of crop
+      rate = 0.0000290                  // 0.5 units required per unit of crop, i.e. 200 days * 900 "4 seconds" per hour * 24 hours * rate == 0.5 * crop_size
     }
 
     INPUT_RESOURCE
     {
       name = CarbonDioxide
-      rate = 0.00557                    // Matched to Oxygen output, by comparing the molecular mass ratio, and the density ratio to arrive at rate ratio
+      rate = 0.0106                     // Matched to Oxygen output, by comparing the molecular mass ratio, and the density ratio to arrive at rate ratio, total ratio used is CO2 rate = 1.0088 * O2 rate
     }
 
     OUTPUT_RESOURCE
     {
       name = Oxygen
-      rate = 0.00552                    // 20% of oxygen required by 1 crew member
+      rate = 0.0105                     // 38% of oxygen required by 1 crew member
     }
 
     OUTPUT_RESOURCE
     {
       name = WasteWater
-      rate = 0.00000382                 // Waste is assumed to dissolve into the water, WasteWater has higher density than Water
+      rate = 0.0000145                  // WasteWater is equal to half input Water, Waste is assumed to dissolve into the water, WasteWater has higher density than Water
     }
   }
   

--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -50,14 +50,6 @@
 		surface = 23.56
 	}
 }
-@PART[sspx-tube-375-*]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
-{
-	@MODULE[Habitat]
-	{
-		volume = 8.95
-		surface = 13.09
-	}
-}
 @PART[sspx-habitation-25-*]:NEEDS[StationPartsExpansion,FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]

--- a/GameData/Kerbalism/System/Resources.cfg
+++ b/GameData/Kerbalism/System/Resources.cfg
@@ -5,7 +5,7 @@
 RESOURCE_DEFINITION
 {
   name = Atmosphere
-  density = 0.000001251          // nitrogen at STP at STP in units metric tonne/L or Mg/dm^3 (factor 1 million smaller than typical units kg/m^3)
+  density = 0.000001251          // nitrogen at STP in units metric tonne/L or Mg/dm^3 (factor 1 million smaller than typical units kg/m^3)
   unitCost = 0.0
   flowMode = ALL_VESSEL
   transfer = PUMP

--- a/GameData/Kerbalism/System/Resources.cfg
+++ b/GameData/Kerbalism/System/Resources.cfg
@@ -5,7 +5,7 @@
 RESOURCE_DEFINITION
 {
   name = Atmosphere
-  density = 0.001251          // 1 m^3 of nitrogen at STP
+  density = 0.000001251          // nitrogen at STP at STP in units metric tonne/L or Mg/dm^3 (factor 1 million smaller than typical units kg/m^3)
   unitCost = 0.0
   flowMode = ALL_VESSEL
   transfer = PUMP
@@ -17,7 +17,7 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
   name = WasteAtmosphere
-  density = 0.001951          // 1 m^3 of carbon dioxide at STP
+  density = 0.000001951          // carbon dioxide at STP in units metric tonne/L or Mg/dm^3 (factor 1 million smaller than typical units kg/m^3)
   unitCost = 0.0
   flowMode = ALL_VESSEL
   transfer = NONE

--- a/src/Modules/Habitat.cs
+++ b/src/Modules/Habitat.cs
@@ -18,8 +18,8 @@ namespace KERBALISM
 		[KSPField(isPersistant = true)] private double perctDeployed = 0;
 
 		// rmb ui status strings
-		[KSPField(guiActive = false, guiActiveEditor = true, guiName = "#KERBALISM_Habitat_Surface")] public string Volume;
-		[KSPField(guiActive = false, guiActiveEditor = true, guiName = "#KERBALISM_Habitat_Volume")] public string Surface;
+		[KSPField(guiActive = false, guiActiveEditor = true, guiName = "#KERBALISM_Habitat_Volume")] public string Volume;
+		[KSPField(guiActive = false, guiActiveEditor = true, guiName = "#KERBALISM_Habitat_Surface")] public string Surface;
 
 		// animations
 		Animator inflate_anim;


### PR DESCRIPTION
This is an attempt at getting food production back to realistic levels, as well some minor related things that I found along the way. Food production is a huge constraint on any mission beyond low orbit, and the current levels didn't at all match up with reality, especially the buff of SSPX modules was over the top, considering they have habitats inside as well.

It also adds Carbon Dioxide processing, which is what plants do for us.

I'm using the pull request to get a build (so not tested until I say so :-P).

Please review, including all the comments and rationales and such. This is not a trivial change, so I expect some extended testing will be necessary. 