### PR TITLE
UI Scale tweeks and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
  * A first attempt at scaling Kerbalism UI to follow KSP UI scaling
  ** By default using the scaling configured for KSP, with an additional scale factor in Settings.cfg if needed to overrule the default
- ** Some tooltips, such as the comfort and radiation will not show perfectly aligned text, but the content is there and the font readable
+ * Clicking the middle mouse button on the popout menu will now close the popout window if it is already open.
  * Humidity Control and a new Life Support Unit part (curtesy of PiezPiedPy)
  * Scale down food production to realistic levels, and make it dependent on CO2 (madman2003)
  ** Every kerbal now requires 2x Kerbalism greenhouse, or 3x 2.5m SSPX greenhouses, or 6x 3.5m SSPX greenhouses for permanent food production

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -1300,7 +1300,7 @@ Profile
   {
     name = ProcessController
     resource = _Sabatier
-    title = Sabatier process
+    title = Sabatier process LF priority
     capacity = 1
   }
 

--- a/GameData/Kerbalism/Settings.cfg
+++ b/GameData/Kerbalism/Settings.cfg
@@ -60,6 +60,6 @@ Kerbalism
   MessageLength = 4                   // duration of messages on screen in seconds
   LowQualityRendering = false         // use less particles to render the magnetic fields
   UIScale = 1.0                       // scale UI elements by this factor, relative to KSP scaling settings, useful for high DPI screens
-  UIPanelWidthScale = 1.0            // scale UI Panel Width by this factor, relative to KSP scaling settings, useful for high DPI screens
+  UIPanelWidthScale = 1.0             // scale UI Panel Width by this factor, relative to KSP scaling settings, useful for high DPI screens
 }
 

--- a/GameData/Kerbalism/Settings.cfg
+++ b/GameData/Kerbalism/Settings.cfg
@@ -59,6 +59,7 @@ Kerbalism
   StockMessages = false               // use the stock message system instead of our own
   MessageLength = 4                   // duration of messages on screen in seconds
   LowQualityRendering = false         // use less particles to render the magnetic fields
-  UIScale = 1.0                       // scale UI elements by this factor, relative to KSP scaling settings, useful for high PPI screens
+  UIScale = 1.0                       // scale UI elements by this factor, relative to KSP scaling settings, useful for high DPI screens
+  UIPanelWidthScale = 1.0            // scale UI Panel Width by this factor, relative to KSP scaling settings, useful for high DPI screens
 }
 

--- a/src/Modules/Comfort.cs
+++ b/src/Modules/Comfort.cs
@@ -161,13 +161,13 @@ namespace KERBALISM
 			string no = Lib.BuildString("<b><color=#ff0000>", Localizer.Format("#KERBALISM_Generic_NO"), " </color></b>");
 			return Lib.BuildString
 			(
-			  "<align=left />",
-			  Localizer.Format("#KERBALISM_Comfort_firmground"), "\t", firm_ground ? yes : no, "\n",
-			  Localizer.Format("#KERBALISM_Comfort_exercise"), "\t\t", exercise ? yes : no, "\n",
-			  Localizer.Format("#KERBALISM_Comfort_notalone"), "\t", not_alone ? yes : no, "\n",
-			  Localizer.Format("#KERBALISM_Comfort_callhome"), "\t", call_home ? yes : no, "\n",
-			  Localizer.Format("#KERBALISM_Comfort_panorama"), "\t", panorama ? yes : no, "\n",
-			  "<i>", Localizer.Format("#KERBALISM_Comfort_factor"), "</i>\t\t", Lib.HumanReadablePerc(factor)
+				"<align=left />",
+				String.Format("{0,-14}\t{1}\n", Localizer.Format("#KERBALISM_Comfort_firmground"), firm_ground ? yes : no),
+				String.Format("{0,-14}\t{1}\n", Localizer.Format("#KERBALISM_Comfort_exercise"), exercise ? yes : no),
+				String.Format("{0,-14}\t{1}\n", Localizer.Format("#KERBALISM_Comfort_notalone"), not_alone ? yes : no),
+				String.Format("{0,-14}\t{1}\n", Localizer.Format("#KERBALISM_Comfort_callhome"), call_home ? yes : no),
+				String.Format("{0,-14}\t{1}\n", Localizer.Format("#KERBALISM_Comfort_panorama"), panorama ? yes : no),
+				String.Format("<i>{0,-14}</i>\t{1}", Localizer.Format("#KERBALISM_Comfort_factor"), Lib.HumanReadablePerc(factor))
 			);
 		}
 

--- a/src/Modules/Configure.cs
+++ b/src/Modules/Configure.cs
@@ -488,7 +488,8 @@ namespace KERBALISM
 			}
 
 			// set metadata
-			p.title(Lib.BuildString("Configure <color=#cccccc>", title, "</color>"));
+			p.title(Lib.BuildString("Configure <color=#cccccc>", Lib.Ellipsis(title, Styles.ScaleStringLength(40)), "</color>"));
+			p.width(Styles.ScaleWidthFloat(300.0f));
 		}
 
 		void render_panel(Panel p, ConfigureSetup setup, int selected_i, int setup_i)
@@ -502,11 +503,11 @@ namespace KERBALISM
 			// only allow reconfiguration if there are more setups than slots
 			if (unlocked.Count <= selected.Count)
 			{
-				p.section(setup.name, setup.desc);
+				p.section(Lib.Ellipsis(setup.name, Styles.ScaleStringLength(70)), setup.desc);
 			}
 			else
 			{
-				p.section(setup.name, setup.desc, () => change_setup(-1, selected_i, ref setup_i), () => change_setup(1, selected_i, ref setup_i));
+				p.section(Lib.Ellipsis(setup.name, Styles.ScaleStringLength(70)), setup.desc, () => change_setup(-1, selected_i, ref setup_i), () => change_setup(1, selected_i, ref setup_i));
 			}
 
 			// render details

--- a/src/Modules/Sensor.cs
+++ b/src/Modules/Sensor.cs
@@ -122,10 +122,10 @@ namespace KERBALISM
 				case "temperature":
 					return Lib.BuildString
 					(
-					  "<align=left />",
-					  "solar flux\t<b>", Lib.HumanReadableFlux(vi.solar_flux), "</b>\n",
-					  "albedo flux\t<b>", Lib.HumanReadableFlux(vi.albedo_flux), "</b>\n",
-					  "body flux\t<b>", Lib.HumanReadableFlux(vi.body_flux), "</b>"
+						"<align=left />",
+						String.Format("{0,-14}\t<b>{1}</b>\n", "solar flux", Lib.HumanReadableFlux(vi.solar_flux)),
+						String.Format("{0,-14}\t<b>{1}</b>\n", "albedo flux", Lib.HumanReadableFlux(vi.albedo_flux)),
+						String.Format("{0,-14}\t<b>{1}</b>", "body flux", Lib.HumanReadableFlux(vi.body_flux))
 					);
 
 				case "radiation":
@@ -145,9 +145,9 @@ namespace KERBALISM
 				case "gravioli":
 					return Lib.BuildString
 					(
-					  "Gravioli detection events per-year: <b>", vi.gravioli.ToString("F2"), "</b>\n\n",
-					  "<i>The elusive negative gravioli particle\nseem to be much harder to detect\n",
-					  "than expected. On the other\nside there seems to be plenty\nof useless positive graviolis around.</i>"
+						"Gravioli detection events per-year: <b>", vi.gravioli.ToString("F2"), "</b>\n\n",
+						"<i>The elusive negative gravioli particle\nseems to be much harder to detect\n",
+						"than expected. On the other\nhand there seems to be plenty\nof useless positive graviolis around.</i>"
 					);
 			}
 			return string.Empty;

--- a/src/System/Settings.cs
+++ b/src/System/Settings.cs
@@ -86,7 +86,8 @@ namespace KERBALISM
 			MessageLength = Lib.ConfigValue(cfg, "MessageLength", 4.0f);
 			LowQualityRendering = Lib.ConfigValue(cfg, "LowQualityRendering", false);
 			UIScale = Lib.ConfigValue(cfg, "UIScale", 1.0f);
-		}
+			UIPanelWidthScale = Lib.ConfigValue(cfg, "UIPanelWidthScale", 1.0f);
+        }
 
 
 		// profile used
@@ -154,6 +155,7 @@ namespace KERBALISM
 		public static float MessageLength;                     // duration of messages on screen in seconds
 		public static bool LowQualityRendering;               // use less particles to render the magnetic fields
 		public static float UIScale;                          // scale UI elements by this factor, relative to KSP scaling settings, useful for high PPI screens
+		public static float UIPanelWidthScale;                // scale UI Panel Width by this factor, relative to KSP scaling settings, useful for high PPI screens
 	}
 
 

--- a/src/UI/BodyInfo.cs
+++ b/src/UI/BodyInfo.cs
@@ -75,7 +75,7 @@ namespace KERBALISM
 			p.content("<i>Press <b>B</b> to open this window again</i>");
 
 			// set metadata
-			p.title(Lib.BuildString(Lib.Ellipsis(body.bodyName, 24), " <color=#cccccc>BODY INFO</color>"));
+			p.title(Lib.BuildString(Lib.Ellipsis(body.bodyName, Styles.ScaleStringLength(24)), " <color=#cccccc>BODY INFO</color>"));
 		}
 	}
 

--- a/src/UI/DevManager.cs
+++ b/src/UI/DevManager.cs
@@ -24,7 +24,7 @@ namespace KERBALISM
 			if (!vi.is_valid) return;
 
 			// set metadata
-			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, 24), " <color=#cccccc>" + Localizer.Format("#KERBALISM_UI_devman") + "</color>"));
+			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, Styles.ScaleStringLength(24)), " <color=#cccccc>" + Localizer.Format("#KERBALISM_UI_devman") + "</color>"));
 
 			// time-out simulation
 			if (p.timeout(vi)) return;

--- a/src/UI/DevManager.cs
+++ b/src/UI/DevManager.cs
@@ -26,6 +26,7 @@ namespace KERBALISM
 			// set metadata
 			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, Styles.ScaleStringLength(20)), " <color=#cccccc>" + Localizer.Format("#KERBALISM_UI_devman") + "</color>"));
 			p.width(Styles.ScaleWidthFloat(355.0f));
+			p.paneltype = Panel.PanelType.scripts;
 
 			// time-out simulation
 			if (p.timeout(vi)) return;

--- a/src/UI/DevManager.cs
+++ b/src/UI/DevManager.cs
@@ -25,6 +25,8 @@ namespace KERBALISM
 
 			// set metadata
 			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, Styles.ScaleStringLength(24)), " <color=#cccccc>" + Localizer.Format("#KERBALISM_UI_devman") + "</color>"));
+			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, Styles.ScaleStringLength(20)), " <color=#cccccc>" + Localizer.Format("#KERBALISM_UI_devman") + "</color>"));
+			p.width(Styles.ScaleWidthFloat(355.0f));
 
 			// time-out simulation
 			if (p.timeout(vi)) return;

--- a/src/UI/DevManager.cs
+++ b/src/UI/DevManager.cs
@@ -24,7 +24,6 @@ namespace KERBALISM
 			if (!vi.is_valid) return;
 
 			// set metadata
-			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, Styles.ScaleStringLength(24)), " <color=#cccccc>" + Localizer.Format("#KERBALISM_UI_devman") + "</color>"));
 			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, Styles.ScaleStringLength(20)), " <color=#cccccc>" + Localizer.Format("#KERBALISM_UI_devman") + "</color>"));
 			p.width(Styles.ScaleWidthFloat(355.0f));
 

--- a/src/UI/FileManager.cs
+++ b/src/UI/FileManager.cs
@@ -43,7 +43,7 @@ namespace KERBALISM
 			{
 				string filename = pair.Key;
 				File file = pair.Value;
-				render_file(p, filename, file, drive, in_monitor && Lib.IsFlight());
+				render_file(p, filename, file, drive, short_strings && Lib.IsFlight());
 			}
 			if (drive.files.Count == 0) p.content("<i>no files</i>", string.Empty);
 
@@ -53,7 +53,7 @@ namespace KERBALISM
 			{
 				string filename = pair.Key;
 				Sample sample = pair.Value;
-				render_sample(p, filename, sample, drive, in_monitor && Lib.IsFlight());
+				render_sample(p, filename, sample, drive, short_strings && Lib.IsFlight());
 			}
 			if (drive.samples.Count == 0) p.content("<i>no samples</i>", string.Empty);
 		}

--- a/src/UI/FileManager.cs
+++ b/src/UI/FileManager.cs
@@ -67,9 +67,9 @@ namespace KERBALISM
 			string exp_label = Lib.BuildString
 			(
 			  "<b>",
-			  Lib.Ellipsis(exp.name, Styles.ScaleStringLength(short_strings ? 24 : 40)),
+			  Lib.Ellipsis(exp.name, Styles.ScaleStringLength(short_strings ? 24 : 38)),
 			  "</b> <size=", Styles.ScaleInteger(10).ToString(), ">",
-			  Lib.Ellipsis(exp.situation, Styles.ScaleStringLength((short_strings ? 37 : 70) - Math.Min((short_strings ? 24 : 40), exp.name.Length))),
+			  Lib.Ellipsis(exp.situation, Styles.ScaleStringLength((short_strings ? 32 : 62) - Lib.Ellipsis(exp.name, Styles.ScaleStringLength(short_strings ? 24 : 38)).Length)),
 			  "</size>"
 			);
 			string exp_tooltip = Lib.BuildString
@@ -101,9 +101,9 @@ namespace KERBALISM
 			string exp_label = Lib.BuildString
 			(
 			  "<b>",
-			  Lib.Ellipsis(exp.name, Styles.ScaleStringLength(short_strings ? 24 : 40)),
+			  Lib.Ellipsis(exp.name, Styles.ScaleStringLength(short_strings ? 24 : 38)),
 			  "</b> <size=", Styles.ScaleInteger(10).ToString(), ">",
-			  Lib.Ellipsis(exp.situation, Styles.ScaleStringLength((short_strings ? 37 : 70) - Math.Min((short_strings ? 24 : 40), exp.name.Length))),
+			  Lib.Ellipsis(exp.situation, Styles.ScaleStringLength((short_strings ? 32 : 62) - Lib.Ellipsis(exp.name, Styles.ScaleStringLength(short_strings ? 24 : 38)).Length)),
 			  "</size>"
 			);
 			string exp_tooltip = Lib.BuildString

--- a/src/UI/FileManager.cs
+++ b/src/UI/FileManager.cs
@@ -9,7 +9,8 @@ namespace KERBALISM
 
 	public static class FileManager
 	{
-		public static void fileman(this Panel p, Vessel v)
+
+		public static void fileman(this Panel p, Vessel v, bool in_monitor = false)
 		{
 			// avoid corner-case when this is called in a lambda after scene changes
 			v = FlightGlobals.FindVessel(v.id);
@@ -24,8 +25,8 @@ namespace KERBALISM
 			if (!vi.is_valid) return;
 
 			// set metadata
-			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, 20), " <color=#cccccc>FILE MANAGER</color>"));
-			p.width(Styles.ScaleWidthFloat(320.0f));
+			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, Styles.ScaleStringLength(40)), " <color=#cccccc>FILE MANAGER</color>"));
+			p.width(Styles.ScaleWidthFloat(465.0f));
 
 			// time-out simulation
 			if (p.timeout(vi)) return;
@@ -39,7 +40,7 @@ namespace KERBALISM
 			{
 				string filename = pair.Key;
 				File file = pair.Value;
-				render_file(p, filename, file, drive);
+				render_file(p, filename, file, drive, in_monitor && Lib.IsFlight());
 			}
 			if (drive.files.Count == 0) p.content("<i>no files</i>", string.Empty);
 
@@ -49,12 +50,12 @@ namespace KERBALISM
 			{
 				string filename = pair.Key;
 				Sample sample = pair.Value;
-				render_sample(p, filename, sample, drive);
+				render_sample(p, filename, sample, drive, in_monitor && Lib.IsFlight());
 			}
 			if (drive.samples.Count == 0) p.content("<i>no samples</i>", string.Empty);
 		}
 
-		static void render_file(Panel p, string filename, File file, Drive drive)
+		static void render_file(Panel p, string filename, File file, Drive drive, bool in_monitor)
 		{
 			// get experiment info
 			ExperimentInfo exp = Science.experiment(filename);
@@ -63,9 +64,9 @@ namespace KERBALISM
 			string exp_label = Lib.BuildString
 			(
 			  "<b>",
-			  Lib.Ellipsis(exp.name, 24),
-			  "</b> <size=10>",
-			  Lib.Ellipsis(exp.situation, 32u - (uint)Math.Min(24, exp.name.Length)),
+			  Lib.Ellipsis(exp.name, Styles.ScaleStringLength(in_monitor ? 24 : 40)),
+			  "</b> <size=", Styles.ScaleInteger(10).ToString(), ">",
+			  Lib.Ellipsis(exp.situation, Styles.ScaleStringLength((in_monitor ? 37 : 70) - Math.Min((in_monitor ? 24 : 40), exp.name.Length))),
 			  "</size>"
 			);
 			string exp_tooltip = Lib.BuildString
@@ -88,7 +89,7 @@ namespace KERBALISM
 		}
 
 
-		static void render_sample(Panel p, string filename, Sample sample, Drive drive)
+		static void render_sample(Panel p, string filename, Sample sample, Drive drive, bool in_monitor)
 		{
 			// get experiment info
 			ExperimentInfo exp = Science.experiment(filename);
@@ -97,9 +98,9 @@ namespace KERBALISM
 			string exp_label = Lib.BuildString
 			(
 			  "<b>",
-			  Lib.Ellipsis(exp.name, 24),
-			  "</b> <size=10>",
-			  Lib.Ellipsis(exp.situation, 32u - (uint)Math.Min(24, exp.name.Length)),
+			  Lib.Ellipsis(exp.name, Styles.ScaleStringLength(in_monitor ? 24 : 40)),
+			  "</b> <size=", Styles.ScaleInteger(10).ToString(), ">",
+			  Lib.Ellipsis(exp.situation, Styles.ScaleStringLength((in_monitor ? 37 : 70) - Math.Min((in_monitor ? 24 : 40), exp.name.Length))),
 			  "</size>"
 			);
 			string exp_tooltip = Lib.BuildString

--- a/src/UI/FileManager.cs
+++ b/src/UI/FileManager.cs
@@ -10,7 +10,10 @@ namespace KERBALISM
 	public static class FileManager
 	{
 
-		public static void fileman(this Panel p, Vessel v, bool in_monitor = false)
+		/// <summary>
+		/// If short_strings parameter is true then the strings used for display of the data will be shorter when inflight.
+		/// </summary>
+		public static void fileman(this Panel p, Vessel v, bool short_strings = false)
 		{
 			// avoid corner-case when this is called in a lambda after scene changes
 			v = FlightGlobals.FindVessel(v.id);
@@ -55,7 +58,7 @@ namespace KERBALISM
 			if (drive.samples.Count == 0) p.content("<i>no samples</i>", string.Empty);
 		}
 
-		static void render_file(Panel p, string filename, File file, Drive drive, bool in_monitor)
+		static void render_file(Panel p, string filename, File file, Drive drive, bool short_strings)
 		{
 			// get experiment info
 			ExperimentInfo exp = Science.experiment(filename);
@@ -64,9 +67,9 @@ namespace KERBALISM
 			string exp_label = Lib.BuildString
 			(
 			  "<b>",
-			  Lib.Ellipsis(exp.name, Styles.ScaleStringLength(in_monitor ? 24 : 40)),
+			  Lib.Ellipsis(exp.name, Styles.ScaleStringLength(short_strings ? 24 : 40)),
 			  "</b> <size=", Styles.ScaleInteger(10).ToString(), ">",
-			  Lib.Ellipsis(exp.situation, Styles.ScaleStringLength((in_monitor ? 37 : 70) - Math.Min((in_monitor ? 24 : 40), exp.name.Length))),
+			  Lib.Ellipsis(exp.situation, Styles.ScaleStringLength((short_strings ? 37 : 70) - Math.Min((short_strings ? 24 : 40), exp.name.Length))),
 			  "</size>"
 			);
 			string exp_tooltip = Lib.BuildString
@@ -89,7 +92,7 @@ namespace KERBALISM
 		}
 
 
-		static void render_sample(Panel p, string filename, Sample sample, Drive drive, bool in_monitor)
+		static void render_sample(Panel p, string filename, Sample sample, Drive drive, bool short_strings)
 		{
 			// get experiment info
 			ExperimentInfo exp = Science.experiment(filename);
@@ -98,9 +101,9 @@ namespace KERBALISM
 			string exp_label = Lib.BuildString
 			(
 			  "<b>",
-			  Lib.Ellipsis(exp.name, Styles.ScaleStringLength(in_monitor ? 24 : 40)),
+			  Lib.Ellipsis(exp.name, Styles.ScaleStringLength(short_strings ? 24 : 40)),
 			  "</b> <size=", Styles.ScaleInteger(10).ToString(), ">",
-			  Lib.Ellipsis(exp.situation, Styles.ScaleStringLength((in_monitor ? 37 : 70) - Math.Min((in_monitor ? 24 : 40), exp.name.Length))),
+			  Lib.Ellipsis(exp.situation, Styles.ScaleStringLength((short_strings ? 37 : 70) - Math.Min((short_strings ? 24 : 40), exp.name.Length))),
 			  "</size>"
 			);
 			string exp_tooltip = Lib.BuildString

--- a/src/UI/FileManager.cs
+++ b/src/UI/FileManager.cs
@@ -30,8 +30,9 @@ namespace KERBALISM
 			// set metadata
 			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, Styles.ScaleStringLength(40)), " <color=#cccccc>FILE MANAGER</color>"));
 			p.width(Styles.ScaleWidthFloat(465.0f));
+			p.paneltype = Panel.PanelType.data;
 
-			// time-out simulation
+ 			// time-out simulation
 			if (p.timeout(vi)) return;
 
 			// get vessel drive

--- a/src/UI/Message.cs
+++ b/src/UI/Message.cs
@@ -50,10 +50,10 @@ namespace KERBALISM
 			style.stretchHeight = true;
 			style.fixedWidth = 0;
 			style.fixedHeight = 0;
-			style.fontSize = 12;
+			style.fontSize = Styles.ScaleInteger(12);
 			style.alignment = TextAnchor.MiddleCenter;
 			style.border = new RectOffset(0, 0, 0, 0);
-			style.padding = new RectOffset(2, 2, 2, 2);
+			style.padding = new RectOffset(Styles.ScaleInteger(2), Styles.ScaleInteger(2), Styles.ScaleInteger(2), Styles.ScaleInteger(2));
 
 			if (all_logs == null)
 			{
@@ -185,8 +185,7 @@ namespace KERBALISM
 		}
 
 
-		// constants
-		const float offset = 266.0f;
+		float offset = Styles.ScaleFloat(266.0f);
 
 		// store entries
 		Queue<Entry> entries = new Queue<Entry>();

--- a/src/UI/Monitor.cs
+++ b/src/UI/Monitor.cs
@@ -107,7 +107,7 @@ namespace KERBALISM
 				switch (page)
 				{
 					case MonitorPage.telemetry: panel.telemetry(selected_v); break;
-					case MonitorPage.data: panel.fileman(selected_v, true); break;
+					case MonitorPage.data: panel.fileman(selected_v, true); break;  // Using short_strings parameter to stop overlapping when inflight.
 					case MonitorPage.scripts: panel.devman(selected_v); break;
 					case MonitorPage.config: panel.config(selected_v); break;
 					case MonitorPage.log: panel.logman(selected_v); break;

--- a/src/UI/Monitor.cs
+++ b/src/UI/Monitor.cs
@@ -265,7 +265,7 @@ namespace KERBALISM
 			GUILayout.Label(new GUIContent(" GROUP ", Icons.small_search, "Organize in groups"), config_style);
 			vd.group = Lib.TextFieldPlaceholder("Kerbalism_group", vd.group, "NONE", group_style).ToUpper();
 			GUILayout.EndHorizontal();
-			GUILayout.Space(10.0f);
+			GUILayout.Space(Styles.ScaleFloat(10.0f));
 		}
 
 
@@ -275,7 +275,7 @@ namespace KERBALISM
 			GUILayout.BeginHorizontal(Styles.entry_container);
 			filter = Lib.TextFieldPlaceholder("Kerbalism_filter", filter, filter_placeholder, filter_style).ToUpper();
 			GUILayout.EndHorizontal();
-			GUILayout.Space(10.0f);
+			GUILayout.Space(Styles.ScaleFloat(10.0f));
 		}
 
 

--- a/src/UI/Monitor.cs
+++ b/src/UI/Monitor.cs
@@ -107,7 +107,7 @@ namespace KERBALISM
 				switch (page)
 				{
 					case MonitorPage.telemetry: panel.telemetry(selected_v); break;
-					case MonitorPage.data: panel.fileman(selected_v); break;
+					case MonitorPage.data: panel.fileman(selected_v, true); break;
 					case MonitorPage.scripts: panel.devman(selected_v); break;
 					case MonitorPage.config: panel.config(selected_v); break;
 					case MonitorPage.log: panel.logman(selected_v); break;
@@ -205,7 +205,10 @@ namespace KERBALISM
 			// render entry
 			p.header
 			(
-			  Lib.BuildString("<b>", Lib.Ellipsis(vessel_name, 20), "</b> <size=", Styles.ScaleInteger(9).ToString(), "><color=#cccccc>", Lib.Ellipsis(body_name, 8), "</color></size>"),
+			  Lib.BuildString("<b>",
+			  Lib.Ellipsis(vessel_name, Styles.ScaleStringLength(((page == MonitorPage.data || page == MonitorPage.log || selected_id == Guid.Empty) && !Lib.IsFlight()) ? 50 : 30)),
+			  "</b> <size=", Styles.ScaleInteger(9).ToString(),
+			  "><color=#cccccc>", Lib.Ellipsis(body_name, Styles.ScaleStringLength(8)), "</color></size>"),
 			  string.Empty,
 			  () => { selected_id = selected_id != v.id ? v.id : Guid.Empty; }
 			);

--- a/src/UI/Monitor.cs
+++ b/src/UI/Monitor.cs
@@ -235,33 +235,63 @@ namespace KERBALISM
 
 		void render_menu(Vessel v)
 		{
-			const string tooltip = "\n<i>(middle-click to popout in a window)</i>";
+			const string tooltip = "\n<i>(middle-click to popout in a window, middle-click again to close popout)</i>";
 			VesselData vd = DB.Vessel(v);
 			GUILayout.BeginHorizontal(Styles.entry_container);
 			GUILayout.Label(new GUIContent(page == MonitorPage.telemetry ? " <color=#00ffff>INFO</color> " : " INFO ", Icons.small_info, "Telemetry readings" + tooltip), config_style);
 			if (Lib.IsClicked()) page = MonitorPage.telemetry;
-			else if (Lib.IsClicked(2)) UI.open((p) => p.telemetry(v));
+			else if (Lib.IsClicked(2))
+			{
+				if (UI.window.PanelType == Panel.PanelType.telemetry)
+					UI.window.close();
+				else
+					UI.open((p) => p.telemetry(v));
+			}
 			if (Features.Science)
 			{
 				GUILayout.Label(new GUIContent(page == MonitorPage.data ? " <color=#00ffff>DATA</color> " : " DATA ", Icons.small_folder, "Stored files and samples" + tooltip), config_style);
 				if (Lib.IsClicked()) page = MonitorPage.data;
-				else if (Lib.IsClicked(2)) UI.open((p) => p.fileman(v));
+				else if (Lib.IsClicked(2))
+				{
+					if (UI.window.PanelType == Panel.PanelType.data)
+						UI.window.close();
+					else
+						UI.open((p) => p.fileman(v));
+				}
 			}
 			if (Features.Automation)
 			{
 				GUILayout.Label(new GUIContent(page == MonitorPage.scripts ? " <color=#00ffff>AUTO</color> " : " AUTO ", Icons.small_console, "Control and automate components" + tooltip), config_style);
 				if (Lib.IsClicked()) page = MonitorPage.scripts;
-				else if (Lib.IsClicked(2)) UI.open((p) => p.devman(v));
+				else if (Lib.IsClicked(2))
+				{
+					if (UI.window.PanelType == Panel.PanelType.scripts)
+						UI.window.close();
+					else
+						UI.open((p) => p.devman(v));
+				}
 			}
 			if (Settings.StockMessages != true)
 			{
 				GUILayout.Label(new GUIContent(page == MonitorPage.log ? " <color=#00ffff>LOG</color> " : " LOG ", Icons.small_notes, "See previous notifications" + tooltip), config_style);
 				if (Lib.IsClicked()) page = MonitorPage.log;
-				else if (Lib.IsClicked(2)) UI.open((p) => p.logman(v));
+				else if (Lib.IsClicked(2))
+				{
+					if (UI.window.PanelType == Panel.PanelType.log)
+						UI.window.close();
+					else
+						UI.open((p) => p.logman(v));
+				}
 			}
 			GUILayout.Label(new GUIContent(page == MonitorPage.config ? " <color=#00ffff>CFG</color> " : " CFG ", Icons.small_config, "Configure the vessel" + tooltip), config_style);
 			if (Lib.IsClicked()) page = MonitorPage.config;
-			else if (Lib.IsClicked(2)) UI.open((p) => p.config(v));
+			else if (Lib.IsClicked(2))
+			{
+				if (UI.window.PanelType == Panel.PanelType.config)
+					UI.window.close();
+				else
+					UI.open((p) => p.config(v));
+			}
 			GUILayout.Label(new GUIContent(" GROUP ", Icons.small_search, "Organize in groups"), config_style);
 			vd.group = Lib.TextFieldPlaceholder("Kerbalism_group", vd.group, "NONE", group_style).ToUpper();
 			GUILayout.EndHorizontal();

--- a/src/UI/Monitor.cs
+++ b/src/UI/Monitor.cs
@@ -148,11 +148,11 @@ namespace KERBALISM
 
 		public float width()
 		{
-			if (page == MonitorPage.log)
+			if ((page == MonitorPage.data || page == MonitorPage.log || selected_id == Guid.Empty) && !Lib.IsFlight())
 			{
-				return Math.Max(Styles.ScaleWidthFloat(465.0f), panel.width());
+				return Styles.ScaleWidthFloat(465.0f);
 			}
-			return Math.Max(Styles.ScaleWidthFloat(355.0f), panel.width());
+			return Styles.ScaleWidthFloat(355.0f);
 		}
 
 		public float height()

--- a/src/UI/NotificationLog.cs
+++ b/src/UI/NotificationLog.cs
@@ -9,8 +9,8 @@ namespace KERBALISM
 	{
 		public static void logman(this Panel p, Vessel v)
 		{
-			p.title("<color=#cccccc>ALL LOGS</color>");
-			p.width(320.0f);
+			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, Styles.ScaleStringLength(40)), " <color=#cccccc>ALL LOGS</color>"));
+			p.width(Styles.ScaleWidthFloat(465.0f));
 			p.section("LOGS");
 			if (Message.all_logs == null || Message.all_logs.Count == 0)
 			{

--- a/src/UI/NotificationLog.cs
+++ b/src/UI/NotificationLog.cs
@@ -11,6 +11,8 @@ namespace KERBALISM
 		{
 			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, Styles.ScaleStringLength(40)), " <color=#cccccc>ALL LOGS</color>"));
 			p.width(Styles.ScaleWidthFloat(465.0f));
+			p.paneltype = Panel.PanelType.log;
+
 			p.section("LOGS");
 			if (Message.all_logs == null || Message.all_logs.Count == 0)
 			{

--- a/src/UI/Panel.cs
+++ b/src/UI/Panel.cs
@@ -10,6 +10,16 @@ namespace KERBALISM
 	// store and render a simple structured ui
 	public sealed class Panel
 	{
+		public enum PanelType
+		{
+			unknown,
+			telemetry,
+			data,
+			scripts,
+			config,
+			log
+		}
+
 		public Panel()
 		{
 			headers = new List<Header>();
@@ -17,6 +27,7 @@ namespace KERBALISM
 			callbacks = new List<Action>();
 			win_title = string.Empty;
 			min_width = Styles.ScaleWidthFloat(280.0f);
+			paneltype = PanelType.unknown;
 		}
 
 		public void clear()
@@ -25,6 +36,7 @@ namespace KERBALISM
 			sections.Clear();
 			win_title = string.Empty;
 			min_width = Styles.ScaleWidthFloat(280.0f);
+			paneltype = PanelType.unknown;
 		}
 
 		public void header(string label, string tooltip = "", Action click = null)
@@ -268,6 +280,7 @@ namespace KERBALISM
 		List<Action> callbacks;  // functions to call on input events
 		string win_title;  // metadata stored in panel
 		float min_width;  // metadata stored in panel
+		public PanelType paneltype;
 	}
 
 

--- a/src/UI/Panel.cs
+++ b/src/UI/Panel.cs
@@ -16,7 +16,7 @@ namespace KERBALISM
 			sections = new List<Section>();
 			callbacks = new List<Action>();
 			win_title = string.Empty;
-			min_width = Styles.ScaleFloat(280.0f);
+			min_width = Styles.ScaleWidthFloat(280.0f);
 		}
 
 		public void clear()
@@ -24,7 +24,7 @@ namespace KERBALISM
 			headers.Clear();
 			sections.Clear();
 			win_title = string.Empty;
-			min_width = Styles.ScaleFloat(280.0f);
+			min_width = Styles.ScaleWidthFloat(280.0f);
 		}
 
 		public void header(string label, string tooltip = "", Action click = null)

--- a/src/UI/Panel.cs
+++ b/src/UI/Panel.cs
@@ -16,7 +16,7 @@ namespace KERBALISM
 			sections = new List<Section>();
 			callbacks = new List<Action>();
 			win_title = string.Empty;
-			min_width = Styles.ScaleFloat(260.0f);
+			min_width = Styles.ScaleFloat(280.0f);
 		}
 
 		public void clear()
@@ -24,7 +24,7 @@ namespace KERBALISM
 			headers.Clear();
 			sections.Clear();
 			win_title = string.Empty;
-			min_width = Styles.ScaleFloat(260.0f);
+			min_width = Styles.ScaleFloat(280.0f);
 		}
 
 		public void header(string label, string tooltip = "", Action click = null)

--- a/src/UI/Planner.cs
+++ b/src/UI/Planner.cs
@@ -170,7 +170,7 @@ namespace KERBALISM
 
 		public float width()
 		{
-			return Styles.ScaleWidthFloat(260.0f);
+			return Styles.ScaleWidthFloat(280.0f);
 		}
 
 

--- a/src/UI/Planner.cs
+++ b/src/UI/Planner.cs
@@ -191,20 +191,21 @@ namespace KERBALISM
 		{
 			string flux_tooltip = Lib.BuildString
 			(
-			  "<align=left /><b>source\t\tflux\t\ttemp</b>\n",
-			  "solar\t\t", env.solar_flux > 0.0 ? Lib.HumanReadableFlux(env.solar_flux) : "none\t", "\t", Lib.HumanReadableTemp(Sim.BlackBodyTemperature(env.solar_flux)), "\n",
-			  "albedo\t\t", env.albedo_flux > 0.0 ? Lib.HumanReadableFlux(env.albedo_flux) : "none\t", "\t", Lib.HumanReadableTemp(Sim.BlackBodyTemperature(env.albedo_flux)), "\n",
-			  "body\t\t", env.body_flux > 0.0 ? Lib.HumanReadableFlux(env.body_flux) : "none\t", "\t", Lib.HumanReadableTemp(Sim.BlackBodyTemperature(env.body_flux)), "\n",
-			  "background\t", Lib.HumanReadableFlux(Sim.BackgroundFlux()), "\t", Lib.HumanReadableTemp(Sim.BlackBodyTemperature(Sim.BackgroundFlux())), "\n",
-			  "total\t\t", Lib.HumanReadableFlux(env.total_flux), "\t", Lib.HumanReadableTemp(Sim.BlackBodyTemperature(env.total_flux))
+				"<align=left />" +
+				String.Format("<b>{0,-14}\t{1,-15}\t{2}</b>\n", "Source", "Flux", "Temp"),
+				String.Format("{0,-14}\t{1,-15}\t{2}\n", "solar", env.solar_flux > 0.0 ? Lib.HumanReadableFlux(env.solar_flux) : "none", Lib.HumanReadableTemp(Sim.BlackBodyTemperature(env.solar_flux))),
+				String.Format("{0,-14}\t{1,-15}\t{2}\n", "albedo", env.albedo_flux > 0.0 ? Lib.HumanReadableFlux(env.albedo_flux) : "none", Lib.HumanReadableTemp(Sim.BlackBodyTemperature(env.albedo_flux))),
+				String.Format("{0,-14}\t{1,-15}\t{2}\n", "body", env.body_flux > 0.0 ? Lib.HumanReadableFlux(env.body_flux) : "none", Lib.HumanReadableTemp(Sim.BlackBodyTemperature(env.body_flux))),
+				String.Format("{0,-14}\t{1,-15}\t{2}\n", "background", Lib.HumanReadableFlux(Sim.BackgroundFlux()), Lib.HumanReadableTemp(Sim.BlackBodyTemperature(Sim.BackgroundFlux()))),
+				String.Format("{0,-14}\t\t{1,-15}\t{2}", "total", Lib.HumanReadableFlux(env.total_flux), Lib.HumanReadableTemp(Sim.BlackBodyTemperature(env.total_flux)))
 			);
 			string atmosphere_tooltip = Lib.BuildString
 			(
-			  "<align=left />",
-			  "breathable\t\t<b>", Sim.Breathable(env.body) ? "yes" : "no", "</b>\n",
-			  "pressure\t\t<b>", Lib.HumanReadablePressure(env.body.atmospherePressureSeaLevel), "</b>\n",
-			  "light absorption\t\t<b>", Lib.HumanReadablePerc(1.0 - env.atmo_factor), "</b>\n",
-			  "gamma absorption\t<b>", Lib.HumanReadablePerc(1.0 - Sim.GammaTransparency(env.body, 0.0)), "</b>"
+				"<align=left />",
+				String.Format("{0,-14}\t<b>{1}</b>\n", "breathable", Sim.Breathable(env.body) ? "yes" : "no"),
+				String.Format("{0,-14}\t<b>{1}</b>\n", "pressure", Lib.HumanReadablePressure(env.body.atmospherePressureSeaLevel)),
+				String.Format("{0,-14}\t<b>{1}</b>\n", "light absorption", Lib.HumanReadablePerc(1.0 - env.atmo_factor)),
+				String.Format("{0,-14}\t<b>{1}</b>", "gamma absorption", Lib.HumanReadablePerc(1.0 - Sim.GammaTransparency(env.body, 0.0)))
 			);
 			string shadowtime_str = Lib.HumanReadableDuration(env.shadow_period) + " (" + (env.shadow_time * 100.0).ToString("F0") + "%)";
 
@@ -264,8 +265,8 @@ namespace KERBALISM
 			// generate details tooltips
 			string living_space_tooltip = Lib.BuildString
 			(
-			  "volume per-capita: <b>", Lib.HumanReadableVolume(va.volume / (double)Math.Max(va.crew_count, 1)), "</b>\n",
-			  "ideal living space: <b>", Lib.HumanReadableVolume(Settings.IdealLivingSpace), "</b>"
+				"volume per-capita:<b>\t", Lib.HumanReadableVolume(va.volume / (double)Math.Max(va.crew_count, 1)), "</b>\n",
+				"ideal living space:<b>\t", Lib.HumanReadableVolume(Settings.IdealLivingSpace), "</b>"
 			);
 			p.content("living space", Habitat.living_space_to_string(va.living_space), living_space_tooltip);
 
@@ -284,7 +285,7 @@ namespace KERBALISM
 			{
 				string pressure_tooltip = va.pressurized
 				  ? "Free roaming in a pressurized environment is\nvastly superior to living in a suit."
-				  : "Being forced inside a suit all the time greatly\nreduce the crew quality of life.\nThe worst part is the diaper.";
+				  : "Being forced inside a suit all the time greatly\nreduces the crews quality of life.\nThe worst part is the diaper.";
 				p.content("pressurized", va.pressurized ? "yes" : "no", pressure_tooltip);
 			}
 			else
@@ -336,14 +337,14 @@ namespace KERBALISM
 			var mf = Radiation.Info(env.body).model;
 			string tooltip = Lib.BuildString
 			(
-			  "<align=left />",
-			  "surface\t\t<b>", Lib.HumanReadableDuration(estimates[0]), "</b>\n",
-			  mf.has_pause ? Lib.BuildString("magnetopause\t<b>", Lib.HumanReadableDuration(estimates[1]), "</b>\n") : "",
-			  mf.has_inner ? Lib.BuildString("inner belt\t<b>", Lib.HumanReadableDuration(estimates[2]), "</b>\n") : "",
-			  mf.has_outer ? Lib.BuildString("outer belt\t<b>", Lib.HumanReadableDuration(estimates[3]), "</b>\n") : "",
-			  "interplanetary\t<b>", Lib.HumanReadableDuration(estimates[4]), "</b>\n",
-			  "interstellar\t<b>", Lib.HumanReadableDuration(estimates[5]), "</b>\n",
-			  "storm\t\t<b>", Lib.HumanReadableDuration(estimates[6]), "</b>"
+				"<align=left />",
+				String.Format("{0,-20}\t<b>{1}</b>\n", "surface", Lib.HumanReadableDuration(estimates[0])),
+				mf.has_pause ? String.Format("{0,-20}\t<b>{1}</b>\n", "magnetopause", Lib.HumanReadableDuration(estimates[1])) : "",
+				mf.has_inner ? String.Format("{0,-20}\t<b>{1}</b>\n", "inner belt", Lib.HumanReadableDuration(estimates[2])) : "",
+				mf.has_outer ? String.Format("{0,-20}\t<b>{1}</b>\n", "outer belt", Lib.HumanReadableDuration(estimates[3])) : "",
+				String.Format("{0,-20}\t<b>{1}</b>\n", "interplanetary", Lib.HumanReadableDuration(estimates[4])),
+				String.Format("{0,-20}\t<b>{1}</b>\n", "interstellar", Lib.HumanReadableDuration(estimates[5])),
+				String.Format("{0,-20}\t<b>{1}</b>", "storm", Lib.HumanReadableDuration(estimates[6]))
 			);
 
 			// render the panel

--- a/src/UI/Styles.cs
+++ b/src/UI/Styles.cs
@@ -147,7 +147,7 @@ namespace KERBALISM
 		// Increasing font size does not affect width as much as height. To avoid excessively wide UIs we scale with UIPanelWidthSScale rather than	UIScale
 		public static float ScaleWidthFloat(float val)
 		{
-			return val * (1.0f + (Settings.UIPanelWidthScale * GameSettings.UI_SCALE * GameSettings.UI_SCALE_APPS - 1.0f));
+			return val * Settings.UIPanelWidthScale * GameSettings.UI_SCALE * GameSettings.UI_SCALE_APPS;
 		}
 
 		public static uint ScaleStringLength(int val)

--- a/src/UI/Styles.cs
+++ b/src/UI/Styles.cs
@@ -150,6 +150,11 @@ namespace KERBALISM
 			return val * (1.0f + (Settings.UIPanelWidthScale * GameSettings.UI_SCALE * GameSettings.UI_SCALE_APPS - 1.0f));
 		}
 
+		public static uint ScaleStringLength(int val)
+		{
+			return (uint)ScaleWidthFloat(val / Settings.UIScale * GameSettings.UI_SCALE * GameSettings.UI_SCALE_APPS);
+		}
+
 		public static Texture2D GetUIScaledTexture(string name)
 		{
 			Texture2D unscaled = Lib.GetTexture(name);

--- a/src/UI/Styles.cs
+++ b/src/UI/Styles.cs
@@ -152,7 +152,7 @@ namespace KERBALISM
 
 		public static uint ScaleStringLength(int val)
 		{
-			return (uint)ScaleWidthFloat(val / Settings.UIScale * GameSettings.UI_SCALE * GameSettings.UI_SCALE_APPS);
+			return (uint)ScaleWidthFloat(val / (Settings.UIScale * Settings.UIScale * GameSettings.UI_SCALE * GameSettings.UI_SCALE_APPS));
 		}
 
 		public static Texture2D GetUIScaledTexture(string name)

--- a/src/UI/Styles.cs
+++ b/src/UI/Styles.cs
@@ -144,12 +144,10 @@ namespace KERBALISM
 			return val * Settings.UIScale * GameSettings.UI_SCALE * GameSettings.UI_SCALE_APPS;
 		}
 
-		// Increasing font size does not affect width as much as height. To avoid excessively wide UIs we scale differently.
-		// Scaling by 80% is simply an emperical factor that is intended to leave the default UI width of 100% scaling intact,
-		// while having a sensible width at high scale value (e.g. 170%).
+		// Increasing font size does not affect width as much as height. To avoid excessively wide UIs we scale with UIPanelWidthSScale rather than	UIScale
 		public static float ScaleWidthFloat(float val)
 		{
-			return val * (1.0f + (Settings.UIScale * GameSettings.UI_SCALE * GameSettings.UI_SCALE_APPS - 1.0f) * 0.8f);
+			return val * (1.0f + (Settings.UIPanelWidthScale * GameSettings.UI_SCALE * GameSettings.UI_SCALE_APPS - 1.0f));
 		}
 
 		public static Texture2D GetUIScaledTexture(string name)

--- a/src/UI/Telemetry.cs
+++ b/src/UI/Telemetry.cs
@@ -25,6 +25,7 @@ namespace KERBALISM
 
 			// set metadata
 			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, Styles.ScaleStringLength(20)), " <color=#cccccc>TELEMETRY</color>"));
+			p.width(Styles.ScaleWidthFloat(355.0f));
 
 			// time-out simulation
 			if (p.timeout(vi)) return;
@@ -182,7 +183,7 @@ namespace KERBALISM
 				string name = kerbal.name.ToLower().Replace(" kerman", string.Empty);
 
 				// render selectable title
-				p.content(Lib.Ellipsis(name, Styles.ScaleStringLength(20)), kd.disabled ? "<color=#00ffff>HYBERNATED</color>" : string.Empty);
+				p.content(Lib.Ellipsis(name, Styles.ScaleStringLength(30)), kd.disabled ? "<color=#00ffff>HYBERNATED</color>" : string.Empty);
 				p.icon(health_severity == 0 ? Icons.health_white : health_severity == 1 ? Icons.health_yellow : Icons.health_red, tooltip);
 				p.icon(stress_severity == 0 ? Icons.brain_white : stress_severity == 1 ? Icons.brain_yellow : Icons.brain_red, tooltip);
 			}

--- a/src/UI/Telemetry.cs
+++ b/src/UI/Telemetry.cs
@@ -24,7 +24,7 @@ namespace KERBALISM
 			if (!vi.is_valid) return;
 
 			// set metadata
-			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, 20), " <color=#cccccc>TELEMETRY</color>"));
+			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, Styles.ScaleStringLength(20)), " <color=#cccccc>TELEMETRY</color>"));
 
 			// time-out simulation
 			if (p.timeout(vi)) return;
@@ -182,7 +182,7 @@ namespace KERBALISM
 				string name = kerbal.name.ToLower().Replace(" kerman", string.Empty);
 
 				// render selectable title
-				p.content(Lib.Ellipsis(name, 20), kd.disabled ? "<color=#00ffff>HYBERNATED</color>" : string.Empty);
+				p.content(Lib.Ellipsis(name, Styles.ScaleStringLength(20)), kd.disabled ? "<color=#00ffff>HYBERNATED</color>" : string.Empty);
 				p.icon(health_severity == 0 ? Icons.health_white : health_severity == 1 ? Icons.health_yellow : Icons.health_red, tooltip);
 				p.icon(stress_severity == 0 ? Icons.brain_white : stress_severity == 1 ? Icons.brain_yellow : Icons.brain_red, tooltip);
 			}

--- a/src/UI/Telemetry.cs
+++ b/src/UI/Telemetry.cs
@@ -26,6 +26,7 @@ namespace KERBALISM
 			// set metadata
 			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, Styles.ScaleStringLength(20)), " <color=#cccccc>TELEMETRY</color>"));
 			p.width(Styles.ScaleWidthFloat(355.0f));
+			p.paneltype = Panel.PanelType.telemetry;
 
 			// time-out simulation
 			if (p.timeout(vi)) return;

--- a/src/UI/UI.cs
+++ b/src/UI/UI.cs
@@ -14,7 +14,7 @@ namespace KERBALISM
 			// create subsystems
 			message = new Message();
 			launcher = new Launcher();
-			window = new Window(260u, DB.ui.win_left, DB.ui.win_top);
+			window = new Window((uint)Styles.ScaleWidthFloat(280), DB.ui.win_left, DB.ui.win_top);
 		}
 
 		public static void sync()

--- a/src/UI/UI.cs
+++ b/src/UI/UI.cs
@@ -69,7 +69,7 @@ namespace KERBALISM
 
 		static Message message;
 		static Launcher launcher;
-		static Window window;
+		public static Window window;
 	}
 
 

--- a/src/UI/VesselConfig.cs
+++ b/src/UI/VesselConfig.cs
@@ -25,6 +25,7 @@ namespace KERBALISM
 
 			// set metadata
 			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, Styles.ScaleStringLength(20)), " <color=#cccccc>VESSEL CONFIG</color>"));
+			p.width(Styles.ScaleWidthFloat(355.0f));
 
 			// time-out simulation
 			if (p.timeout(vi)) return;

--- a/src/UI/VesselConfig.cs
+++ b/src/UI/VesselConfig.cs
@@ -26,6 +26,7 @@ namespace KERBALISM
 			// set metadata
 			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, Styles.ScaleStringLength(20)), " <color=#cccccc>VESSEL CONFIG</color>"));
 			p.width(Styles.ScaleWidthFloat(355.0f));
+			p.paneltype = Panel.PanelType.config;
 
 			// time-out simulation
 			if (p.timeout(vi)) return;

--- a/src/UI/VesselConfig.cs
+++ b/src/UI/VesselConfig.cs
@@ -24,7 +24,7 @@ namespace KERBALISM
 			if (!vi.is_valid) return;
 
 			// set metadata
-			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, 20), " <color=#cccccc>VESSEL CONFIG</color>"));
+			p.title(Lib.BuildString(Lib.Ellipsis(v.vesselName, Styles.ScaleStringLength(20)), " <color=#cccccc>VESSEL CONFIG</color>"));
 
 			// time-out simulation
 			if (p.timeout(vi)) return;

--- a/src/UI/Window.cs
+++ b/src/UI/Window.cs
@@ -141,6 +141,16 @@ namespace KERBALISM
 			return (uint)win_rect.yMin;
 		}
 
+		public Panel.PanelType PanelType
+		{
+			get
+			{
+				if (panel == null)
+					return Panel.PanelType.unknown;
+				else
+					return panel.paneltype;
+			}
+		}
 
 		// store window id
 		int win_id;

--- a/src/UI/Window.cs
+++ b/src/UI/Window.cs
@@ -67,7 +67,7 @@ namespace KERBALISM
 			// adapt window size to panel
 			// - clamp to screen height
 			win_rect.width = Math.Min(panel.width(), Screen.width * 0.75f);
-			win_rect.height = Math.Min(20.0f + panel.height(), Screen.height * 0.75f);
+			win_rect.height = Math.Min(Styles.ScaleFloat(20.0f) + panel.height(), Screen.height * 0.75f);
 
 			// clamp the window to the screen, so it can't be dragged outside
 			float offset_x = Math.Max(0.0f, -win_rect.xMin) + Math.Min(0.0f, Screen.width - win_rect.xMax);

--- a/src/UI/Window.cs
+++ b/src/UI/Window.cs
@@ -23,7 +23,7 @@ namespace KERBALISM
 			win_rect = new Rect((float)left, (float)top, (float)width, 0.0f);
 
 			// setup dragbox geometry
-			drag_rect = new Rect(0.0f, 0.0f, width, 20.0f);
+			drag_rect = new Rect(0.0f, 0.0f, (float)width, Styles.ScaleFloat(20.0f));
 
 			// initialize tooltip utility
 			tooltip = new Tooltip();
@@ -66,8 +66,8 @@ namespace KERBALISM
 
 			// adapt window size to panel
 			// - clamp to screen height
-			win_rect.width = Math.Min(panel.width(), Screen.width * 0.75f);
-			win_rect.height = Math.Min(Styles.ScaleFloat(20.0f) + panel.height(), Screen.height * 0.75f);
+			win_rect.width = Math.Min(panel.width(), Screen.width * 0.8f);
+			win_rect.height = Math.Min(Styles.ScaleFloat(20.0f) + panel.height(), Screen.height * 0.8f);
 
 			// clamp the window to the screen, so it can't be dragged outside
 			float offset_x = Math.Max(0.0f, -win_rect.xMin) + Math.Min(0.0f, Screen.width - win_rect.xMax);


### PR DESCRIPTION
Added `UIPanelWidthScale` user setting, allows the user to have a separate scale for the width of the UI windows.
* Reason I added this feature is that after I applied a UI scale, the InFlight Monitor panel was partially underneath my KER window. I had a feeling users would probably have the same problem, so I came up with this setting to change the width scale of the panels independently of the UI Scale.

Scaled the string lengths in the windows to stop overlapping.

Scaled the Alert Messages.

InFlight Monitor panels are now the same size to help stop overlapping.

Space Centre Monitor panels for science data , message log and unselected vessels are now wider than the other panels to show more information.

Science data and message log popout windows are now wider than the other popout windows again to show more information.

Popout windows no longer show a scroll bar due to their height not scaling enough.

All tooltips now have correct alignment of data.

Clicking the middle mouse button on the popout menu will now close the popout window if it is already open.

Message Log window still needs some work and certain scales still upset the tooltips but that can be addressed in a later PR.

I will post some pictures 😉 