### PR TITLE
Simulate in planner button for antennas

### DIFF
--- a/GameData/Kerbalism/System/Planner.cfg
+++ b/GameData/Kerbalism/System/Planner.cfg
@@ -65,3 +65,11 @@
   }
 }
 
+
+@PART[*]:HAS[@MODULE[ModuleDataTransmitter]]:AFTER[Kerbalism]
+{
+  MODULE
+  {
+    name = PlannerController
+  }
+}


### PR DESCRIPTION
I've added a planner controller to the `DataTransmitter` Modules which means the simulate in planner button for antennas is now back.