### PR TITLE
ContractConfigurator support changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v1.6.1 for KSP 1.4.3
+ - 2018-xx-xx
+
+### Changes since the last release
+
+  *  Fix ContractConfigurator bug (PiezPiedPy)
+
+### For Developers
+
+
 ## v1.6.0 for KSP 1.4.3
  - 2018-05-26
 

--- a/GameData/Kerbalism/Kerbalism.version
+++ b/GameData/Kerbalism/Kerbalism.version
@@ -6,7 +6,7 @@
   "VERSION": {
     "MAJOR": 1,
     "MINOR": 6,
-    "PATCH": 0,
+    "PATCH": 1,
     "BUILD": 0
   },
   "KSP_VERSION": {

--- a/GameData/Kerbalism/Support/ContractConfigurator.cfg
+++ b/GameData/Kerbalism/Support/ContractConfigurator.cfg
@@ -5,19 +5,11 @@
   {
     @partModule = Laboratory
   }
-  @PARAMETER[*]:HAS[#partModule[ModuleDataTransmitter]]:NEEDS[FeatureSignal]
-  {
-    @partModule = Antenna
-  }
   @PARAMETER[*]
   {
     @PARAMETER[*]:HAS[#partModule[ModuleScienceLab]]:NEEDS[FeatureScience]
     {
       @partModule = Laboratory
-    }
-    @PARAMETER[*]:HAS[#partModule[ModuleDataTransmitter]]:NEEDS[FeatureSignal]
-    {
-      @partModule = Antenna
     }
     @PARAMETER[*]
     {
@@ -25,19 +17,11 @@
       {
         @partModule = Laboratory
       }
-      @PARAMETER[*]:HAS[#partModule[ModuleDataTransmitter]]:NEEDS[FeatureSignal]
-      {
-        @partModule = Antenna
-      }
       @PARAMETER[*]
       {
         @PARAMETER[*]:HAS[#partModule[ModuleScienceLab]]:NEEDS[FeatureScience]
         {
           @partModule = Laboratory
-        }
-        @PARAMETER[*]:HAS[#partModule[ModuleDataTransmitter]]:NEEDS[FeatureSignal]
-        {
-          @partModule = Antenna
         }
       }
     }
@@ -46,19 +30,11 @@
   {
     @partModule = Laboratory
   }
-  @REQUIREMENT[*]:HAS[#partModule[ModuleDataTransmitter]]:NEEDS[FeatureSignal]
-  {
-    @partModule = Antenna
-  }
   @REQUIREMENT[*]
   {
     @REQUIREMENT[*]:HAS[#partModule[ModuleScienceLab]]:NEEDS[FeatureScience]
     {
       @partModule = Laboratory
-    }
-    @REQUIREMENT[*]:HAS[#partModule[ModuleDataTransmitter]]:NEEDS[FeatureSignal]
-    {
-      @partModule = Antenna
     }
     @REQUIREMENT[*]
     {
@@ -66,19 +42,11 @@
       {
         @partModule = Laboratory
       }
-      @REQUIREMENT[*]:HAS[#partModule[ModuleDataTransmitter]]:NEEDS[FeatureSignal]
-      {
-        @partModule = Antenna
-      }
       @REQUIREMENT[*]
       {
         @REQUIREMENT[*]:HAS[#partModule[ModuleScienceLab]]:NEEDS[FeatureScience]
         {
           @partModule = Laboratory
-        }
-        @REQUIREMENT[*]:HAS[#partModule[ModuleDataTransmitter]]:NEEDS[FeatureSignal]
-        {
-          @partModule = Antenna
         }
       }
     }

--- a/GameData/Kerbalism/Support/ContractConfigurator.cfg
+++ b/GameData/Kerbalism/Support/ContractConfigurator.cfg
@@ -1,50 +1,50 @@
 // Gotmachine
-@CONTRACT_TYPE[*]:NEEDS[ContractConfigurator]:FINAL
+@CONTRACT_TYPE[*]:NEEDS[ContractConfigurator,Kerbalism,FeatureScience]:AFTER[Kerbalism]
 {
-  @PARAMETER[*]:HAS[#partModule[ModuleScienceLab]]:NEEDS[FeatureScience]
+  @PARAMETER[*]:HAS[#partModule[ModuleScienceLab]]
   {
     @partModule = Laboratory
   }
   @PARAMETER[*]
   {
-    @PARAMETER[*]:HAS[#partModule[ModuleScienceLab]]:NEEDS[FeatureScience]
+    @PARAMETER[*]:HAS[#partModule[ModuleScienceLab]]
     {
       @partModule = Laboratory
     }
     @PARAMETER[*]
     {
-      @PARAMETER[*]:HAS[#partModule[ModuleScienceLab]]:NEEDS[FeatureScience]
+      @PARAMETER[*]:HAS[#partModule[ModuleScienceLab]]
       {
         @partModule = Laboratory
       }
       @PARAMETER[*]
       {
-        @PARAMETER[*]:HAS[#partModule[ModuleScienceLab]]:NEEDS[FeatureScience]
+        @PARAMETER[*]:HAS[#partModule[ModuleScienceLab]]
         {
           @partModule = Laboratory
         }
       }
     }
   }
-  @REQUIREMENT[*]:HAS[#partModule[ModuleScienceLab]]:NEEDS[FeatureScience]
+  @REQUIREMENT[*]:HAS[#partModule[ModuleScienceLab]]
   {
     @partModule = Laboratory
   }
   @REQUIREMENT[*]
   {
-    @REQUIREMENT[*]:HAS[#partModule[ModuleScienceLab]]:NEEDS[FeatureScience]
+    @REQUIREMENT[*]:HAS[#partModule[ModuleScienceLab]]
     {
       @partModule = Laboratory
     }
     @REQUIREMENT[*]
     {
-      @REQUIREMENT[*]:HAS[#partModule[ModuleScienceLab]]:NEEDS[FeatureScience]
+      @REQUIREMENT[*]:HAS[#partModule[ModuleScienceLab]]
       {
         @partModule = Laboratory
       }
       @REQUIREMENT[*]
       {
-        @REQUIREMENT[*]:HAS[#partModule[ModuleScienceLab]]:NEEDS[FeatureScience]
+        @REQUIREMENT[*]:HAS[#partModule[ModuleScienceLab]]
         {
           @partModule = Laboratory
         }

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can use the default the Revision and
 // Build Numbers by using the '*' as shown below:
-[assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.6.0.0")]
+[assembly: AssemblyVersion("1.6.1.0")]
+[assembly: AssemblyFileVersion("1.6.1.0")]


### PR DESCRIPTION
Removed all now unused Antenna part references since the Signals feature was removed. Also moved the Needs sections to root.

Fixes the bug raised in Issue #9

Also bumped version to 1.6.1