### PR TITLE
Humidity controller and External ECLSS location in TechTree

### DIFF
--- a/GameData/Kerbalism/Parts/LifeSupport/kerbalism-lifesupportmodule.cfg
+++ b/GameData/Kerbalism/Parts/LifeSupport/kerbalism-lifesupportmodule.cfg
@@ -12,4 +12,5 @@
   @category = Utility
   @description = Seeing the lack of ECLSS redundancy, mission control urgently ordered us to convert this chemical plant to an external ECLSS module. Guaranteed to explode only 147.28% as often as the original.
   %tags = _kerbalism
+  TechRequired = basicScience
 }

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -567,7 +567,7 @@ Profile
     {
       name = Humidity Controller
       desc = Reclaimes <b>Water<b> out of the internal atmosphere to maintain humidity.
-      tech = engineering101
+      tech = survivability
       mass = 0.015
       cost = 300
 
@@ -761,7 +761,6 @@ Profile
     {
       name = Pressure Control
       desc = Use <b>Nitrogen</b> to maintain the internal atmosphere at a comfortable pressure.
-      tech = engineering101
       mass = 0.01
       cost = 250
 
@@ -777,7 +776,6 @@ Profile
     {
       name = Humidity Controller
       desc = Reclaimes <b>Water<b> out of the internal atmosphere to maintain humidity.
-      tech = engineering101
       mass = 0.015
       cost = 300
 


### PR DESCRIPTION
For better balancing in Career mode.

 * Moved Humidity Controller for pods into Survivability.
 * Moved the external ECLSS part into Basic Science.