### PR TITLE
Resolve IDE messages

### DIFF
--- a/src/Automation/Devices/Converter.cs
+++ b/src/Automation/Devices/Converter.cs
@@ -83,9 +83,9 @@ namespace KERBALISM
 			Ctrl(!Lib.Proto.GetBool(converter, "IsActivated"));
 		}
 
-		ProtoPartModuleSnapshot converter;
-		ModuleResourceConverter prefab;
-		uint part_id;
+		private readonly ProtoPartModuleSnapshot converter;
+		private ModuleResourceConverter prefab;
+		private readonly uint part_id;
 	}
 
 

--- a/src/Automation/Devices/Drill.cs
+++ b/src/Automation/Devices/Drill.cs
@@ -84,9 +84,9 @@ namespace KERBALISM
 			Ctrl(!Lib.Proto.GetBool(drill, "IsActivated"));
 		}
 
-		ProtoPartModuleSnapshot drill;
-		ModuleResourceHarvester prefab;
-		uint part_id;
+		private readonly ProtoPartModuleSnapshot drill;
+		private ModuleResourceHarvester prefab;
+		private readonly uint part_id;
 	}
 
 

--- a/src/Automation/Devices/Emitter.cs
+++ b/src/Automation/Devices/Emitter.cs
@@ -77,8 +77,8 @@ namespace KERBALISM
 			Ctrl(!Lib.Proto.GetBool(emitter, "running"));
 		}
 
-		ProtoPartModuleSnapshot emitter;
-		uint part_id;
+		private readonly ProtoPartModuleSnapshot emitter;
+		private readonly uint part_id;
 	}
 
 

--- a/src/Automation/Devices/Experiment.cs
+++ b/src/Automation/Devices/Experiment.cs
@@ -45,8 +45,8 @@ namespace KERBALISM
 			Ctrl(!exp.recording);
 		}
 
-		Experiment exp;
-		string exp_name;
+		private Experiment exp;
+		private readonly string exp_name;
 	}
 
 
@@ -91,10 +91,10 @@ namespace KERBALISM
 			Ctrl(!Lib.Proto.GetBool(exp, "recording"));
 		}
 
-		ProtoPartModuleSnapshot exp;
-		Experiment prefab;
-		uint part_id;
-		string exp_name;
+		private readonly ProtoPartModuleSnapshot exp;
+		private readonly Experiment prefab;
+		private readonly uint part_id;
+		private readonly string exp_name;
 	}
 
 

--- a/src/Automation/Devices/Generator.cs
+++ b/src/Automation/Devices/Generator.cs
@@ -83,9 +83,9 @@ namespace KERBALISM
 			Ctrl(!Lib.Proto.GetBool(generator, "generatorIsActive"));
 		}
 
-		ProtoPartModuleSnapshot generator;
-		ModuleGenerator prefab;
-		uint part_id;
+		private readonly ProtoPartModuleSnapshot generator;
+		private ModuleGenerator prefab;
+		private readonly uint part_id;
 	}
 
 

--- a/src/Automation/Devices/Greenhouse.cs
+++ b/src/Automation/Devices/Greenhouse.cs
@@ -78,8 +78,8 @@ namespace KERBALISM
 			Ctrl(!Lib.Proto.GetBool(greenhouse, "active"));
 		}
 
-		ProtoPartModuleSnapshot greenhouse;
-		uint part_id;
+		private readonly ProtoPartModuleSnapshot greenhouse;
+		private readonly uint part_id;
 	}
 
 

--- a/src/Automation/Devices/Harvester.cs
+++ b/src/Automation/Devices/Harvester.cs
@@ -49,8 +49,8 @@ namespace KERBALISM
 			Ctrl(!harvester.running);
 		}
 
-		Harvester harvester;
-		ModuleAnimationGroup animator;
+		private Harvester harvester;
+		private readonly ModuleAnimationGroup animator;
 	}
 
 
@@ -102,10 +102,10 @@ namespace KERBALISM
 			Ctrl(!Lib.Proto.GetBool(harvester, "running"));
 		}
 
-		ProtoPartModuleSnapshot harvester;
-		ProtoPartModuleSnapshot animator;
-		Harvester prefab;
-		uint part_id;
+		private readonly ProtoPartModuleSnapshot harvester;
+		private readonly ProtoPartModuleSnapshot animator;
+		private Harvester prefab;
+		private readonly uint part_id;
 	}
 
 

--- a/src/Automation/Devices/Laboratory.cs
+++ b/src/Automation/Devices/Laboratory.cs
@@ -77,8 +77,8 @@ namespace KERBALISM
 			Ctrl(!Lib.Proto.GetBool(lab, "running"));
 		}
 
-		ProtoPartModuleSnapshot lab;
-		uint part_id;
+		private readonly ProtoPartModuleSnapshot lab;
+		private readonly uint part_id;
 	}
 
 

--- a/src/Automation/Devices/Light.cs
+++ b/src/Automation/Devices/Light.cs
@@ -79,8 +79,8 @@ namespace KERBALISM
 			Ctrl(!Lib.Proto.GetBool(light, "isOn"));
 		}
 
-		ProtoPartModuleSnapshot light;
-		uint part_id;
+		private readonly ProtoPartModuleSnapshot light;
+		private readonly uint part_id;
 	}
 
 

--- a/src/Automation/Devices/Panel.cs
+++ b/src/Automation/Devices/Panel.cs
@@ -101,9 +101,9 @@ namespace KERBALISM
 			Ctrl(Lib.Proto.GetString(panel, "deployState") != "EXTENDED");
 		}
 
-		ProtoPartModuleSnapshot panel;
-		ModuleDeployableSolarPanel prefab;
-		uint part_id;
+		private readonly ProtoPartModuleSnapshot panel;
+		private ModuleDeployableSolarPanel prefab;
+		private readonly uint part_id;
 	}
 
 

--- a/src/Automation/Devices/Process.cs
+++ b/src/Automation/Devices/Process.cs
@@ -86,9 +86,9 @@ namespace KERBALISM
 			Ctrl(!Lib.Proto.GetBool(process_ctrl, "running"));
 		}
 
-		ProtoPartModuleSnapshot process_ctrl;
-		ProcessController prefab;
-		uint part_id;
+		private readonly ProtoPartModuleSnapshot process_ctrl;
+		private ProcessController prefab;
+		private readonly uint part_id;
 	}
 
 

--- a/src/Automation/Devices/Ring.cs
+++ b/src/Automation/Devices/Ring.cs
@@ -81,8 +81,8 @@ namespace KERBALISM
 			Ctrl(!Lib.Proto.GetBool(ring, "deployed"));
 		}
 
-		ProtoPartModuleSnapshot ring;
-		uint part_id;
+		private readonly ProtoPartModuleSnapshot ring;
+		private readonly uint part_id;
 	}
 
 

--- a/src/Automation/Devices/Scanner.cs
+++ b/src/Automation/Devices/Scanner.cs
@@ -87,10 +87,10 @@ namespace KERBALISM
 			Ctrl(!Lib.Proto.GetBool(scanner, "scanning"));
 		}
 
-		ProtoPartModuleSnapshot scanner;
-		Part part_prefab;
-		Vessel vessel;
-		uint part_id;
+		private readonly ProtoPartModuleSnapshot scanner;
+		private readonly Part part_prefab;
+		private readonly Vessel vessel;
+		private readonly uint part_id;
 	}
 
 

--- a/src/EVA.cs
+++ b/src/EVA.cs
@@ -113,9 +113,11 @@ namespace KERBALISM
 				KFSMState freezed = new KFSMState("freezed");
 
 				// create freeze event
-				KFSMEvent eva_freeze = new KFSMEvent("EVAfreeze");
-				eva_freeze.GoToStateOnEvent = freezed;
-				eva_freeze.updateMode = KFSMUpdateMode.MANUAL_TRIGGER;
+				KFSMEvent eva_freeze = new KFSMEvent("EVAfreeze")
+				{
+					GoToStateOnEvent = freezed,
+					updateMode = KFSMUpdateMode.MANUAL_TRIGGER
+				};
 				kerbal.fsm.AddEvent(eva_freeze, kerbal.fsm.CurrentState);
 
 				// trigger freeze event

--- a/src/Kerbalism.csproj
+++ b/src/Kerbalism.csproj
@@ -58,6 +58,7 @@
     </DefineConstants>
     <DebugType>none</DebugType>
     <Prefer32Bit>false</Prefer32Bit>
+    <NoWarn>IDE0018</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
@@ -68,6 +69,7 @@
     <DefineConstants>TRACE;DEBUG;DEVELOPMENT;ENABLE_PROFILER;DEBUG_PROFILER</DefineConstants>
     <DebugType>full</DebugType>
     <Prefer32Bit>false</Prefer32Bit>
+    <NoWarn>IDE0018</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
@@ -231,6 +233,13 @@
     <Analyzer Condition="Exists('$(KSPDEVDIR)\KSP_x64_Data\Managed\UnityEngine.Networking.dll')" Include="$(KSPDEVDIR)\KSP_x64_Data\Managed\UnityEngine.Networking.dll" />
     <Analyzer Condition="Exists('$(KSPDEVDIR)\KSP_x64_Data\Managed\UnityEngine.UI.dll')" Include="$(KSPDEVDIR)\KSP_x64_Data\Managed\UnityEngine.UI.dll" />
     <Analyzer Condition="Exists('$(KSPDEVDIR)\KSP_x64_Data\Managed\UnityScript.Lang.dll')" Include="$(KSPDEVDIR)\KSP_x64_Data\Managed\UnityScript.Lang.dll" />
+    <Analyzer Condition="Exists('$(KSPDEVDIR)\KSP_x64_Data\Managed\Boo.Lang.dll')" Include="$(KSPDEVDIR)\KSP_x64_Data\Managed\Boo.Lang.dll" />
+    <Analyzer Condition="Exists('$(KSPDEVDIR)\KSP_x64_Data\Managed\KSPTrackIR.dll')" Include="$(KSPDEVDIR)\KSP_x64_Data\Managed\KSPTrackIR.dll" />
+    <Analyzer Condition="Exists('$(KSPDEVDIR)\KSP_x64_Data\Managed\KSPAssets.dll')" Include="$(KSPDEVDIR)\KSP_x64_Data\Managed\KSPAssets.dll" />
+    <Analyzer Condition="Exists('$(KSPDEVDIR)\KSP_x64_Data\Managed\Mono.Cecil.dll')" Include="$(KSPDEVDIR)\KSP_x64_Data\Managed\Mono.Cecil.dll" />
+    <Analyzer Condition="Exists('$(KSPDEVDIR)\KSP_x64_Data\Managed\Ionic.Zip.dll')" Include="$(KSPDEVDIR)\KSP_x64_Data\Managed\Ionic.Zip.dll" />
+    <Analyzer Condition="Exists('$(KSPDEVDIR)\KSP_x64_Data\Managed\TDx.TDxInput.dll')" Include="$(KSPDEVDIR)\KSP_x64_Data\Managed\TDx.TDxInput.dll" />
+    <Analyzer Condition="Exists('$(KSPDEVDIR)\KSP_x64_Data\Managed\RedShellSDK.dll')" Include="$(KSPDEVDIR)\KSP_x64_Data\Managed\RedShellSDK.dll" />
     <Analyzer Condition="Exists('.\Assembly-CSharp-firstpass.dll')" Include=".\Assembly-CSharp-firstpass.dll" />
     <Analyzer Condition="Exists('.\Assembly-CSharp.dll')" Include=".\Assembly-CSharp.dll" />
     <Analyzer Condition="Exists('.\Assembly-UnityScript.dll')" Include=".\Assembly-UnityScript.dll" />

--- a/src/Kerbalism.csproj
+++ b/src/Kerbalism.csproj
@@ -59,6 +59,7 @@
     <DebugType>none</DebugType>
     <Prefer32Bit>false</Prefer32Bit>
     <NoWarn>IDE0018</NoWarn>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
@@ -70,6 +71,7 @@
     <DebugType>full</DebugType>
     <Prefer32Bit>false</Prefer32Bit>
     <NoWarn>IDE0018</NoWarn>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">

--- a/src/Lib.cs
+++ b/src/Lib.cs
@@ -1046,8 +1046,10 @@ namespace KERBALISM
 			Module_prefab_data data;
 			if (!PD.TryGetValue(module_name, out data))
 			{
-				data = new Module_prefab_data();
-				data.prefabs = module_prefabs.FindAll(k => k.moduleName == module_name);
+				data = new Module_prefab_data
+				{
+					prefabs = module_prefabs.FindAll(k => k.moduleName == module_name)
+				};
 				PD.Add(module_name, data);
 			}
 

--- a/src/Lib.cs
+++ b/src/Lib.cs
@@ -716,13 +716,7 @@ namespace KERBALISM
 		{
 			var target = PlanetariumCamera.fetch.target;
 			return
-				target == null
-			  ? null
-			  : target.celestialBody != null
-			  ? target.celestialBody
-			  : target.vessel != null
-			  ? target.vessel.mainBody
-			  : null;
+				target == null ? null : target.celestialBody ?? target.vessel?.mainBody;
 		}
 
 		// return terrain height at point specified
@@ -861,8 +855,10 @@ namespace KERBALISM
 		// get list of parts recursively, useful from the editors
 		public static List<Part> GetPartsRecursively(Part root)
 		{
-			List<Part> ret = new List<Part>();
-			ret.Add(root);
+			List<Part> ret = new List<Part>
+			{
+				root
+			};
 			foreach (Part p in root.children)
 			{
 				ret.AddRange(GetPartsRecursively(p));
@@ -927,11 +923,8 @@ namespace KERBALISM
 					PartModule m = p.Modules[j];
 					if (m.isEnabled)
 					{
-						T t = m as T;
-						if (t != null)
-						{
+						if (m is T t)
 							ret.Add(t);
-						}
 					}
 				}
 			}
@@ -970,11 +963,8 @@ namespace KERBALISM
 					PartModule m = p.Modules[j];
 					if (m.isEnabled)
 					{
-						T t = m as T;
-						if (t != null && filter(t))
-						{
+						if (m is T t && filter(t))
 							return true;
-						}
 					}
 				}
 			}
@@ -1537,7 +1527,7 @@ namespace KERBALISM
 			public static string GetString(ProtoPartModuleSnapshot m, string name, string def_value = "")
 			{
 				string s = m.moduleValues.GetValue(name);
-				return s != null ? s : def_value;
+				return s ?? def_value;
 			}
 
 			// set a value in a proto module

--- a/src/Modules/Configure.cs
+++ b/src/Modules/Configure.cs
@@ -181,11 +181,8 @@ namespace KERBALISM
 					if (m != null)
 					{
 						// call configure/deconfigure functions on module if available
-						IConfigurable configurable_module = m as IConfigurable;
-						if (configurable_module != null)
-						{
+						if (m is IConfigurable configurable_module)
 							configurable_module.Configure(active);
-						}
 
 						// enable/disable the module
 						m.isEnabled = active;
@@ -635,13 +632,12 @@ namespace KERBALISM
 				if (m == null) continue;
 
 				// get title
-				IModuleInfo module_info = m as IModuleInfo;
-				string title = module_info != null ? module_info.GetModuleTitle() : cm.type;
+				string title = m is IModuleInfo module_info ? module_info.GetModuleTitle() : cm.type;
 				if (title.Length == 0) continue;
 
 				// get specs, skip if not implemented by module
-				ISpecifics specifics = m as ISpecifics;
-				if (specifics == null) continue;
+				if (!(m is ISpecifics specifics))
+					continue;
 				Specifics specs = specifics.Specs();
 				if (specs.entries.Count == 0) continue;
 

--- a/src/Modules/Greenhouse.cs
+++ b/src/Modules/Greenhouse.cs
@@ -404,12 +404,14 @@ namespace KERBALISM
 				{
 					if (greenhouse.active)
 					{
-						Data gd = new Data();
-						gd.growth = greenhouse.growth;
-						gd.natural = greenhouse.natural;
-						gd.artificial = greenhouse.artificial;
-						gd.tta = greenhouse.tta;
-						gd.issue = greenhouse.issue;
+						Data gd = new Data
+						{
+							growth = greenhouse.growth,
+							natural = greenhouse.natural,
+							artificial = greenhouse.artificial,
+							tta = greenhouse.tta,
+							issue = greenhouse.issue
+						};
 						ret.Add(gd);
 					}
 				}
@@ -420,12 +422,14 @@ namespace KERBALISM
 				{
 					if (Lib.Proto.GetBool(m, "active"))
 					{
-						Data gd = new Data();
-						gd.growth = Lib.Proto.GetDouble(m, "growth");
-						gd.natural = Lib.Proto.GetDouble(m, "natural");
-						gd.artificial = Lib.Proto.GetDouble(m, "artificial");
-						gd.tta = Lib.Proto.GetDouble(m, "tta");
-						gd.issue = Lib.Proto.GetString(m, "issue");
+						Data gd = new Data
+						{
+							growth = Lib.Proto.GetDouble(m, "growth"),
+							natural = Lib.Proto.GetDouble(m, "natural"),
+							artificial = Lib.Proto.GetDouble(m, "artificial"),
+							tta = Lib.Proto.GetDouble(m, "tta"),
+							issue = Lib.Proto.GetString(m, "issue")
+						};
 						ret.Add(gd);
 					}
 				}

--- a/src/Radiation.cs
+++ b/src/Radiation.cs
@@ -261,9 +261,11 @@ namespace KERBALISM
 			foreach (string s in to_remove) models.Remove(s);
 
 			// start particle-fitting thread
-			preprocess_thread = new Thread(Preprocess);
-			preprocess_thread.Name = "particle-fitting";
-			preprocess_thread.IsBackground = true;
+			preprocess_thread = new Thread(Preprocess)
+			{
+				Name = "particle-fitting",
+				IsBackground = true
+			};
 			preprocess_thread.Start();
 		}
 

--- a/src/Renderer/LineRenderer.cs
+++ b/src/Renderer/LineRenderer.cs
@@ -22,10 +22,12 @@ namespace KERBALISM
 		public static void Commit(Vector3 a, Vector3 b, Color color)
 		{
 			// create a new line
-			Line_data line = new Line_data();
-			line.a = a;
-			line.b = b;
-			line.color = color;
+			Line_data line = new Line_data
+			{
+				a = a,
+				b = b,
+				color = color
+			};
 
 			// commit it
 			lines.Add(line);

--- a/src/Renderer/ParticleRenderer.cs
+++ b/src/Renderer/ParticleRenderer.cs
@@ -79,14 +79,14 @@ namespace KERBALISM
 
 
 
-		const int max_particles = 64000;                           // max particles per-mesh
-		static Vector3[] points = new Vector3[max_particles];      // mesh data: position
-		static Vector2[] sizes = new Vector2[max_particles];       // mesh data: size in pixels
-		static Color32[] colors = new Color32[max_particles];      // mesh data: 32bit color
-		static List<int> indices = new List<int>(max_particles);   // mesh data: indices
-		static Mesh mesh;                                          // mesh used as set of VBA
-		static Material mat;                                       // material used
-		static int point_index;                                    // index of next point in the arrays
+		private const int max_particles = 64000;                                    // max particles per-mesh
+		private readonly static Vector3[] points = new Vector3[max_particles];      // mesh data: position
+		private readonly static Vector2[] sizes = new Vector2[max_particles];       // mesh data: size in pixels
+		private readonly static Color32[] colors = new Color32[max_particles];      // mesh data: 32bit color
+		private static List<int> indices = new List<int>(max_particles);            // mesh data: indices
+		private static Mesh mesh;                                                   // mesh used as set of VBA
+		private static Material mat;                                                // material used
+		private static int point_index;                                             // index of next point in the arrays
 	}
 
 

--- a/src/System/Kerbalism.cs
+++ b/src/System/Kerbalism.cs
@@ -38,8 +38,10 @@ namespace KERBALISM
 				{
 					if (Storm.Skip_body(body))
 						continue;
-					Storm_data sd = new Storm_data();
-					sd.body = body;
+					Storm_data sd = new Storm_data
+					{
+						body = body
+					};
 					storm_bodies.Add(sd);
 				}
 

--- a/src/System/Kerbalism.cs
+++ b/src/System/Kerbalism.cs
@@ -651,8 +651,10 @@ namespace KERBALISM
 			}
 
 			// compile list of events with condition satisfied
-			List<KerbalBreakdown> events = new List<KerbalBreakdown>();
-			events.Add(KerbalBreakdown.mumbling); //< do nothing, here so there is always something that can happen
+			List<KerbalBreakdown> events = new List<KerbalBreakdown>
+			{
+				KerbalBreakdown.mumbling //< do nothing, here so there is always something that can happen
+			};
 			if (Lib.HasData(v))
 				events.Add(KerbalBreakdown.fat_finger);
 			if (Reliability.CanMalfunction(v))

--- a/src/UI/Message.cs
+++ b/src/UI/Message.cs
@@ -185,19 +185,19 @@ namespace KERBALISM
 		}
 
 
-		float offset = Styles.ScaleFloat(266.0f);
+		private readonly float offset = Styles.ScaleFloat(266.0f);
 
 		// store entries
-		Queue<Entry> entries = new Queue<Entry>();
+		private Queue<Entry> entries = new Queue<Entry>();
 
 		// disable message rendering
-		bool muted;
+		private bool muted;
 
 		// styles
-		GUIStyle style;
+		private GUIStyle style;
 
 		// permit global access
-		static Message instance;
+		private static Message instance;
 	}
 
 

--- a/src/UI/Message.cs
+++ b/src/UI/Message.cs
@@ -115,9 +115,11 @@ namespace KERBALISM
 			foreach (Entry e in instance.entries) { if (e.msg == msg) return; }
 
 			// compile entry
-			Entry entry = new Entry();
-			entry.msg = msg;
-			entry.first_seen = 0;
+			Entry entry = new Entry
+			{
+				msg = msg,
+				first_seen = 0
+			};
 
 			// add entry
 			instance.entries.Enqueue(entry);

--- a/src/UI/Monitor.cs
+++ b/src/UI/Monitor.cs
@@ -40,10 +40,12 @@ namespace KERBALISM
 			config_style.fontSize = Styles.ScaleInteger(9);
 
 			// group texfield style
-			group_style = new GUIStyle(config_style);
-			group_style.imagePosition = ImagePosition.TextOnly;
-			group_style.stretchWidth = true;
-			group_style.fixedHeight = Styles.ScaleFloat(11.0f);
+			group_style = new GUIStyle(config_style)
+			{
+				imagePosition = ImagePosition.TextOnly,
+				stretchWidth = true,
+				fixedHeight = Styles.ScaleFloat(11.0f)
+			};
 			group_style.normal.textColor = Color.yellow;
 
 			// initialize panel

--- a/src/UI/Panel.cs
+++ b/src/UI/Panel.cs
@@ -41,43 +41,51 @@ namespace KERBALISM
 
 		public void AddHeader(string label, string tooltip = "", Action click = null)
 		{
-			Header h = new Header();
-			h.label = label;
-			h.tooltip = tooltip;
-			h.click = click;
-			h.icons = new List<Icon>();
+			Header h = new Header
+			{
+				label = label,
+				tooltip = tooltip,
+				click = click,
+				icons = new List<Icon>()
+			};
 			headers.Add(h);
 		}
 
 		public void AddSection(string title, string desc = "", Action left = null, Action right = null)
 		{
-			Section p = new Section();
-			p.title = title;
-			p.desc = desc;
-			p.left = left;
-			p.right = right;
-			p.entries = new List<Entry>();
+			Section p = new Section
+			{
+				title = title,
+				desc = desc,
+				left = left,
+				right = right,
+				entries = new List<Entry>()
+			};
 			sections.Add(p);
 		}
 
 		public void AddContent(string label, string value = "", string tooltip = "", Action click = null, Action hover = null)
 		{
-			Entry e = new Entry();
-			e.label = label;
-			e.value = value;
-			e.tooltip = tooltip;
-			e.click = click;
-			e.hover = hover;
-			e.icons = new List<Icon>();
+			Entry e = new Entry
+			{
+				label = label,
+				value = value,
+				tooltip = tooltip,
+				click = click,
+				hover = hover,
+				icons = new List<Icon>()
+			};
 			if (sections.Count > 0) sections[sections.Count - 1].entries.Add(e);
 		}
 
 		public void AddIcon(Texture texture, string tooltip = "", Action click = null)
 		{
-			Icon i = new Icon();
-			i.texture = texture;
-			i.tooltip = tooltip;
-			i.click = click;
+			Icon i = new Icon
+			{
+				texture = texture,
+				tooltip = tooltip,
+				click = click
+			};
 			if (sections.Count > 0)
 			{
 				Section p = sections[sections.Count - 1];

--- a/src/UI/Planner.cs
+++ b/src/UI/Planner.cs
@@ -465,37 +465,37 @@ namespace KERBALISM
 
 
 		// store situations and altitude multipliers
-		string[] situations = { "Landed", "Low Orbit", "Orbit", "High Orbit" };
-		double[] altitude_mults = { 0.0, 0.33, 1.0, 3.0 };
+		private string[] situations = { "Landed", "Low Orbit", "Orbit", "High Orbit" };
+		private readonly double[] altitude_mults = { 0.0, 0.33, 1.0, 3.0 };
 
 		// styles
-		GUIStyle leftmenu_style;
-		GUIStyle rightmenu_style;
-		GUIStyle quote_style;
-		GUIStyle icon_style;
+		private GUIStyle leftmenu_style;
+		private GUIStyle rightmenu_style;
+		private GUIStyle quote_style;
+		private GUIStyle icon_style;
 
 		// analyzers
-		Resource_simulator sim = new Resource_simulator();
-		Environment_analyzer env = new Environment_analyzer();
-		Vessel_analyzer va = new Vessel_analyzer();
+		private Resource_simulator sim = new Resource_simulator();
+		private Environment_analyzer env = new Environment_analyzer();
+		private Vessel_analyzer va = new Vessel_analyzer();
 
 		// panel arrays
-		List<string> panel_resource;
-		List<string> panel_special;
-		List<string> panel_environment;
+		private List<string> panel_resource;
+		private List<string> panel_special;
+		private List<string> panel_environment;
 
 		// body/situation/sunlight indexes
-		int body_index;
-		int situation_index;
-		bool sunlight;
+		private int body_index;
+		private int situation_index;
+		private bool sunlight;
 
 		// panel indexes
-		int resource_index;
-		int special_index;
-		int environment_index;
+		private int resource_index;
+		private int special_index;
+		private int environment_index;
 
 		// panel ui
-		Panel panel;
+		private Panel panel;
 	}
 
 

--- a/src/UI/Planner.cs
+++ b/src/UI/Planner.cs
@@ -478,9 +478,9 @@ namespace KERBALISM
 
 		// styles
 		private GUIStyle leftmenu_style;
-		private GUIStyle rightmenu_style;
+		private readonly GUIStyle rightmenu_style;
 		private GUIStyle quote_style;
-		private GUIStyle icon_style;
+		private readonly GUIStyle icon_style;
 
 		// analyzers
 		private Resource_simulator sim = new Resource_simulator();

--- a/src/UI/Planner.cs
+++ b/src/UI/Planner.cs
@@ -15,8 +15,10 @@ namespace KERBALISM
 		public Planner()
 		{
 			// left menu style
-			leftmenu_style = new GUIStyle(HighLogic.Skin.label);
-			leftmenu_style.richText = true;
+			leftmenu_style = new GUIStyle(HighLogic.Skin.label)
+			{
+				richText = true
+			};
 			leftmenu_style.normal.textColor = new Color(0.0f, 0.0f, 0.0f, 1.0f);
 			leftmenu_style.fixedWidth = Styles.ScaleWidthFloat(80.0f); // Fixed to avoid that the sun icon moves around for different planet name lengths
 			leftmenu_style.stretchHeight = true;
@@ -24,12 +26,16 @@ namespace KERBALISM
 			leftmenu_style.alignment = TextAnchor.MiddleLeft;
 
 			// right menu style
-			rightmenu_style = new GUIStyle(leftmenu_style);
-			rightmenu_style.alignment = TextAnchor.MiddleRight;
+			rightmenu_style = new GUIStyle(leftmenu_style)
+			{
+				alignment = TextAnchor.MiddleRight
+			};
 
 			// quote style
-			quote_style = new GUIStyle(HighLogic.Skin.label);
-			quote_style.richText = true;
+			quote_style = new GUIStyle(HighLogic.Skin.label)
+			{
+				richText = true
+			};
 			quote_style.normal.textColor = Color.black;
 			quote_style.stretchWidth = true;
 			quote_style.stretchHeight = true;
@@ -37,8 +43,10 @@ namespace KERBALISM
 			quote_style.alignment = TextAnchor.LowerCenter;
 
 			// center icon style
-			icon_style = new GUIStyle();
-			icon_style.alignment = TextAnchor.MiddleCenter;
+			icon_style = new GUIStyle
+			{
+				alignment = TextAnchor.MiddleCenter
+			};
 
 			// set default body index & situation
 			body_index = FlightGlobals.GetHomeBodyIndex();

--- a/src/UI/Styles.cs
+++ b/src/UI/Styles.cs
@@ -18,51 +18,65 @@ namespace KERBALISM
 			win.padding.bottom = 0;
 
 			// window title container
-			title_container = new GUIStyle();
-			title_container.stretchWidth = true;
-			title_container.fixedHeight = ScaleFloat(16.0f);
+			title_container = new GUIStyle
+			{
+				stretchWidth = true,
+				fixedHeight = ScaleFloat(16.0f)
+			};
 			title_container.margin.bottom = ScaleInteger(2);
 			title_container.margin.top = ScaleInteger(2);
 
 			// window title text
-			title_text = new GUIStyle();
-			title_text.fontSize = ScaleInteger(10);
-			title_text.fixedHeight = ScaleFloat(16.0f);
-			title_text.fontStyle = FontStyle.Bold;
-			title_text.alignment = TextAnchor.MiddleCenter;
+			title_text = new GUIStyle
+			{
+				fontSize = ScaleInteger(10),
+				fixedHeight = ScaleFloat(16.0f),
+				fontStyle = FontStyle.Bold,
+				alignment = TextAnchor.MiddleCenter
+			};
 
 			// subsection title container
-			section_container = new GUIStyle();
-			section_container.stretchWidth = true;
-			section_container.fixedHeight = ScaleFloat(16.0f);
+			section_container = new GUIStyle
+			{
+				stretchWidth = true,
+				fixedHeight = ScaleFloat(16.0f)
+			};
 			section_container.normal.background = Lib.GetTexture("black-background");
 			section_container.margin.bottom = ScaleInteger(4);
 			section_container.margin.top = ScaleInteger(4);
 
 			// subsection title text
-			section_text = new GUIStyle(HighLogic.Skin.label);
-			section_text.fontSize = ScaleInteger(12);
-			section_text.alignment = TextAnchor.MiddleCenter;
+			section_text = new GUIStyle(HighLogic.Skin.label)
+			{
+				fontSize = ScaleInteger(12),
+				alignment = TextAnchor.MiddleCenter
+			};
 			section_text.normal.textColor = Color.white;
 			section_text.stretchWidth = true;
 			section_text.stretchHeight = true;
 
 			// entry row container
-			entry_container = new GUIStyle();
-			entry_container.stretchWidth = true;
-			entry_container.fixedHeight = ScaleFloat(16.0f);
+			entry_container = new GUIStyle
+			{
+				stretchWidth = true,
+				fixedHeight = ScaleFloat(16.0f)
+			};
 
 			// entry label text
-			entry_label = new GUIStyle(HighLogic.Skin.label);
-			entry_label.richText = true;
+			entry_label = new GUIStyle(HighLogic.Skin.label)
+			{
+				richText = true
+			};
 			entry_label.normal.textColor = Color.white;
 			entry_label.stretchWidth = true;
 			entry_label.stretchHeight = true;
 			entry_label.fontSize = ScaleInteger(12);
 			entry_label.alignment = TextAnchor.MiddleLeft;
 
-			entry_label_nowrap = new GUIStyle(HighLogic.Skin.label);
-			entry_label_nowrap.richText = true;
+			entry_label_nowrap = new GUIStyle(HighLogic.Skin.label)
+			{
+				richText = true
+			};
 			entry_label_nowrap.normal.textColor = Color.white;
 			entry_label_nowrap.stretchWidth = true;
 			entry_label_nowrap.stretchHeight = true;
@@ -71,8 +85,10 @@ namespace KERBALISM
 			entry_label_nowrap.wordWrap = false;
 
 			// entry value text
-			entry_value = new GUIStyle(HighLogic.Skin.label);
-			entry_value.richText = true;
+			entry_value = new GUIStyle(HighLogic.Skin.label)
+			{
+				richText = true
+			};
 			entry_value.normal.textColor = Color.white;
 			entry_value.stretchWidth = true;
 			entry_value.stretchHeight = true;
@@ -81,13 +97,17 @@ namespace KERBALISM
 			entry_value.fontStyle = FontStyle.Bold;
 
 			// desc row container
-			desc_container = new GUIStyle();
-			desc_container.stretchWidth = true;
-			desc_container.stretchHeight = true;
+			desc_container = new GUIStyle
+			{
+				stretchWidth = true,
+				stretchHeight = true
+			};
 
 			// entry multi-line description
-			desc = new GUIStyle(entry_label);
-			desc.alignment = TextAnchor.UpperLeft;
+			desc = new GUIStyle(entry_label)
+			{
+				alignment = TextAnchor.UpperLeft
+			};
 			desc.margin.top = 0;
 			desc.margin.bottom = 0;
 			desc.padding.top = 0;
@@ -95,14 +115,18 @@ namespace KERBALISM
 			desc.fontStyle = FontStyle.Italic;
 
 			// left icon
-			left_icon = new GUIStyle();
-			left_icon.alignment = TextAnchor.MiddleLeft;
-			left_icon.fixedWidth = ScaleFloat(16.0f);
+			left_icon = new GUIStyle
+			{
+				alignment = TextAnchor.MiddleLeft,
+				fixedWidth = ScaleFloat(16.0f)
+			};
 
 			// right icon
-			right_icon = new GUIStyle();
-			right_icon.alignment = TextAnchor.MiddleRight;
-			right_icon.fixedWidth = ScaleFloat(16.0f);
+			right_icon = new GUIStyle
+			{
+				alignment = TextAnchor.MiddleRight,
+				fixedWidth = ScaleFloat(16.0f)
+			};
 			right_icon.margin.left = ScaleInteger(8);
 
 			// tooltip label style
@@ -118,9 +142,11 @@ namespace KERBALISM
 			tooltip.alignment = TextAnchor.MiddleCenter;
 
 			// tooltip container style
-			tooltip_container = new GUIStyle();
-			tooltip_container.stretchWidth = true;
-			tooltip_container.stretchHeight = true;
+			tooltip_container = new GUIStyle
+			{
+				stretchWidth = true,
+				stretchHeight = true
+			};
 
 			smallStationHead = new GUIStyle(HighLogic.Skin.label)
 			{

--- a/src/UI/Window.cs
+++ b/src/UI/Window.cs
@@ -153,25 +153,25 @@ namespace KERBALISM
 		}
 
 		// store window id
-		int win_id;
+		private readonly int win_id;
 
 		// store window geometry
-		Rect win_rect;
+		private Rect win_rect;
 
 		// store dragbox geometry
-		Rect drag_rect;
+		private Rect drag_rect;
 
 		// used by scroll window mechanics
-		Vector2 scroll_pos;
+		private Vector2 scroll_pos;
 
 		// tooltip utility
-		Tooltip tooltip;
+		private Tooltip tooltip;
 
 		// panel
-		Panel panel;
+		private Panel panel;
 
 		// refresh function
-		Action<Panel> refresh;
+		private Action<Panel> refresh;
 	}
 
 

--- a/src/Utility/Animator.cs
+++ b/src/Utility/Animator.cs
@@ -9,8 +9,8 @@ namespace KERBALISM
 
 	public sealed class Animator
 	{
-		Animation anim;
-		string name;
+		private Animation anim;
+		private readonly string name;
 
 		public Animator(Part p, string anim_name)
 		{

--- a/src/Utility/DumpSpec.cs
+++ b/src/Utility/DumpSpec.cs
@@ -36,8 +36,8 @@ namespace KERBALISM
 			return any || list.Contains(res_name);
 		}
 
-		bool any;
-		List<string> list;
+		private readonly bool any;
+		private List<string> list;
 	}
 
 

--- a/src/Utility/Profiler.cs
+++ b/src/Utility/Profiler.cs
@@ -55,7 +55,7 @@ namespace KERBALISM
 
         // display update timer
         private static double update_timer = Lib.Clocks();
-        private static double timeout = Stopwatch.Frequency / update_fps;
+        private readonly static double timeout = Stopwatch.Frequency / update_fps;
         private const double update_fps = 5.0;      // Frames per second the entry value display will update.
         private static long tot_frames = 0;         // total physics frames used for avg calculation
         private static string tot_frames_txt = "";  // total physics frames display string
@@ -284,7 +284,7 @@ namespace KERBALISM
                 Profiler.Stop(name);
             }
 
-            private string name;
+            private readonly string name;
         }
 
 #endif

--- a/src/Utility/Profiler.cs
+++ b/src/Utility/Profiler.cs
@@ -271,7 +271,7 @@ namespace KERBALISM
 #if DEBUG_PROFILER
 
         /// <summary> Profile a function scope. </summary>
-        public class ProfileScope : IDisposable
+        public sealed class ProfileScope : IDisposable
         {
             public ProfileScope(string name)
             {

--- a/src/Utility/Specifics.cs
+++ b/src/Utility/Specifics.cs
@@ -22,9 +22,11 @@ namespace KERBALISM
 
 		public void Add(string label, string value = "")
 		{
-			Entry e = new Entry();
-			e.label = label;
-			e.value = value;
+			Entry e = new Entry
+			{
+				label = label,
+				value = value
+			};
 			entries.Add(e);
 		}
 

--- a/src/Utility/Transformator.cs
+++ b/src/Utility/Transformator.cs
@@ -4,17 +4,17 @@ namespace KERBALISM
 {
 	public sealed class Transformator
 	{
-		Part part;
-		Transform transf;
-		string name;
+		private readonly Part part;
+		private Transform transf;
+		private readonly string name;
 
-		Quaternion baseAngles;
+		private Quaternion baseAngles;
 
-		float rotationRateGoal = 0f;
-		float CurrentSpinRate = 0f;
+		private float rotationRateGoal = 0f;
+		private float CurrentSpinRate = 0f;
 
-		float SpinRate = 0f;
-		float spinAccel = 0f;
+		private readonly float SpinRate = 0f;
+		private readonly float spinAccel = 0f;
 
 		public Transformator(Part p, string transf_name, float SpinRate, float spinAccel)
 		{


### PR DESCRIPTION
 * Use latest available C# version and pattern matching
 * IDE0018 Message "Variable declaration can be inlined" suppressed because variable declaration inlining does not work on versions of Visual Studio older than VS2017
 * Analyzer references added to solve the IDE1003 errors

 * Add access modifiers to solve IDE0044 messages
 * Simplified object initialization to solve IDE0017 messages
 * Optimizations to remove the last of the IDE messages.