### PR TITLE
Fix for the Module Manager cache bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Changes since the last release
 
+ * Module Manager cache bug fixed (PiezPiedPy)
  * Added an upgrade part to the TechTree that adds a slot to the Manned pods, ECLSS module and Chemical plants (PiezPiedPy)
  * Chemical plant capacity fixed, it was nurfed by accident in a previous release (PiezPiedPy)
  * TechTree locations for Humidity controller and External ECLSS moved for a better Career balance (PiezPiedPy)

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -460,12 +460,13 @@ Profile
 
 PARTUPGRADE
 {
-	name = Upgrade-Slots
-	partIcon = kerbalism-chemicalplant
-	techRequired = electronics
-	entryCost = 20000
-	title = Life support and Chemical plant slot upgrade
-	description = Adds an additional configurable slot to Manned pods, ECLSS module and Chemical plants. 
+  name = Upgrade-Slots
+  partIcon = kerbalism-chemicalplant
+  techRequired = electronics
+  entryCost = 20000
+  title = Life support and Chemical plant slot upgrade
+  manufacturer = Lambda Aerospace 
+  description = Adds an additional configurable slot to Manned pods, ECLSS module and Chemical plants. 
 }
 
 

--- a/GameData/Kerbalism/Support/USI/USI_FTT.cfg
+++ b/GameData/Kerbalism/Support/USI/USI_FTT.cfg
@@ -2,14 +2,14 @@
 // USI_FTT.cfg needs USI_ReactorPack.cfg
 // Kerbalism support patch for Umbra Space Industries FTT
 //   Removes resources not used by Kerbalism from Cargo Pods and adds Kerbalism resources
-//   Adds radiation emmitters.
+//   Adds radiation emitters.
 //   Hydrogen Liquefaction process for creating LqdHydrogen from Hydrogen gas.
 //   Nuclear Reactor process for the reactors.
 //   Remove USIWeightDistribution and USILifeSupport Modules.
 //   Place FTT Parts into suitable Tech Tree locations.
 // ============================================================================
 
-// Wish-List. Options in maybe the settings.cfg or a seperate .cfg file to give the user the ability to remove or not the
+// Wish-List. Options in maybe the settings.cfg or a separate .cfg file to give the user the ability to remove or not the
 //    USI Weight Distribution and USI Life Support Modules. Also I have no idea yet how to implement the options into
 //    the NEEDS[] section
 
@@ -37,7 +37,7 @@ Profile
 // ============================================================================
 // Remove USI WeightDistribution Modules
 // ============================================================================
-@PART[FTT_Engine*]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[FTT_Engine*]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	!MODULE[ModuleWeightDistributableCargo],* {}
 }
@@ -45,7 +45,7 @@ Profile
 // ============================================================================
 // Add a convertor slot to the Orca and remove USI LifeSupport Module
 // ============================================================================
-@PART[FTT_Pod_375_01]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[FTT_Pod_375_01]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	!MODULE[ModuleLifeSupportRecycler],* {}
 
@@ -55,7 +55,7 @@ Profile
 // ============================================================================
 // Remove unused Resources from Cargo Pods and add Kerbalism resources
 // ============================================================================
-@PART[FTT_Cargo_375*]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[FTT_Cargo_375*]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	!MODULE[FSfuelSwitch],* {}
 	!MODULE[FStextureSwitch2]:HAS[#moduleID[0]] {}
@@ -202,7 +202,7 @@ Profile
 	@description = Cargo Pod for transporting various supplies, fuels, liquids and gases.
 }
 
-@PART[FTT_Cargo_375_01]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[FTT_Cargo_375_01]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@cost = 1000
 	@MODULE[Configure]
@@ -250,7 +250,7 @@ Profile
 	}
 }
 
-@PART[FTT_Cargo_375_02]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[FTT_Cargo_375_02]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@cost = 3000
 	@MODULE[Configure]
@@ -301,7 +301,7 @@ Profile
 // ============================================================================
 // Add LqdHydrogen to radial containers
 // ============================================================================
-@PART[kerbalism-container-radial-*]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[kerbalism-container-radial-*]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@MODULE[Configure]
 	{
@@ -326,7 +326,7 @@ Profile
 // ============================================================================
 // Add Hydrogen liquefaction to ISRU chemical plants
 // ============================================================================
-@PART[kerbalism-chemicalplant,MiniISRU,ISRU]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[kerbalism-chemicalplant,MiniISRU,ISRU]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	MODULE
 	{
@@ -354,12 +354,17 @@ Profile
 	}
 }
 
-@PART[MiniISRU]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[kerbalism-chemicalplant]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+{
+	@MODULE[ProcessController]:HAS[#title[*liquefaction*]]{@capacity *= 2.0}
+}
+
+@PART[MiniISRU]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@MODULE[ProcessController]:HAS[#title[*liquefaction*]]{@capacity *= 3.3}
 }
 
-@PART[ISRU]:NEEDS[Kerbalism&ProfileDefault&UmbraSpaceIndustries]:AFTER[UmbraSpaceIndustries]
+@PART[ISRU]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@MODULE[ProcessController]:HAS[#title[*liquefaction*]]{@capacity *= 5.0}
 }
@@ -367,7 +372,7 @@ Profile
 // ============================================================================
 // Add Nuclear reactor process's to all FTT Nuclear reactors and remove ResourceConverter modules
 // ============================================================================
-@PART[FTT_Service_375_01,FTT_Reactor_500_01]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[FTT_Service_375_01,FTT_Reactor_500_01]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	!MODULE[ModuleResourceConverter],* {}
 
@@ -380,12 +385,12 @@ Profile
 	}
 }
 
-@PART[FTT_Service_375_01]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[FTT_Service_375_01]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@MODULE[ProcessController]:HAS[#title[Nuclear?reactor]]{@capacity *= 62.5}
 }
 
-@PART[FTT_Reactor_500_01]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[FTT_Reactor_500_01]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@MODULE[ProcessController]:HAS[#title[Nuclear?reactor]]{@capacity *= 250}
 	@description = Weighing in at nearly forty tons, this nuclear reactor provides ample power for StarLifter-class freighters.
@@ -394,7 +399,7 @@ Profile
 // ============================================================================
 // Add Radiation Emitters to all FTT Nuclear parts
 // ============================================================================
-@PART[FTT_Service_375_01,FTT_Reactor_500_01,FTT_Engine_375_03,FTT_Engine_375_04]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault,FeatureRadiation]:AFTER[UmbraSpaceIndustries]
+@PART[FTT_Service_375_01,FTT_Reactor_500_01,FTT_Engine_375_03,FTT_Engine_375_04]:NEEDS[FTT,Kerbalism,ProfileDefault,FeatureRadiation]:AFTER[UmbraSpaceIndustries]
 {
 	MODULE
 	{
@@ -403,17 +408,17 @@ Profile
 	}
 }
 
-@PART[FTT_Service_375_01,FTT_Engine_375_04]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault,FeatureRadiation]:AFTER[UmbraSpaceIndustries]
+@PART[FTT_Service_375_01,FTT_Engine_375_04]:NEEDS[FTT,Kerbalism,ProfileDefault,FeatureRadiation]:AFTER[UmbraSpaceIndustries]
 {
 	@MODULE[Emitter]{@radiation *= 6.0} // 0.006 rad/h
 }
 
-@PART[FTT_Engine_375_03]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault,FeatureRadiation]:AFTER[UmbraSpaceIndustries]
+@PART[FTT_Engine_375_03]:NEEDS[FTT,Kerbalism,ProfileDefault,FeatureRadiation]:AFTER[UmbraSpaceIndustries]
 {
 	@MODULE[Emitter]{@radiation *= 8.5} // 0.0085 rad/h
 }
 
-@PART[FTT_Reactor_500_01]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault,FeatureRadiation]:AFTER[UmbraSpaceIndustries]
+@PART[FTT_Reactor_500_01]:NEEDS[FTT,Kerbalism,ProfileDefault,FeatureRadiation]:AFTER[UmbraSpaceIndustries]
 {
 	@MODULE[Emitter]{@radiation *= 12.0} // 0.012 rad/h
 }
@@ -421,12 +426,12 @@ Profile
 // ============================================================================
 // Move FTT Reactors to a more suitable Tech Tree location
 // ============================================================================
-@PART[FTT_Service_375_01]:NEEDS[!CommunityTechTree,UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[FTT_Service_375_01]:NEEDS[!CommunityTechTree,FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@TechRequired = largeElectrics
 }
 
-@PART[FTT_Reactor_500_01]:NEEDS[!CommunityTechTree,UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[FTT_Reactor_500_01]:NEEDS[!CommunityTechTree,FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@TechRequired = experimentalElectrics
 }
@@ -434,7 +439,7 @@ Profile
 // ============================================================================
 // Pseudo-resources used by Kerbalism support for USI FTT
 // ============================================================================
-RESOURCE_DEFINITION
+RESOURCE_DEFINITION:NEEDS[FTT,Kerbalism,ProfileDefault]
 {
 	name = _HyLiquefaction
 	density = 0.0

--- a/GameData/Kerbalism/Support/USI/USI_NukeStorage.cfg
+++ b/GameData/Kerbalism/Support/USI/USI_NukeStorage.cfg
@@ -1,13 +1,13 @@
 // ============================================================================
 // USI_NukeStorage.cfg
 // Kerbalism support patch for Umbra Space Industries Nuclear Kontainers
-//   Adds radiation emmitters to Nuclear Fuel Tanks.
+//   Adds radiation emitters to Nuclear Fuel Tanks.
 //   Adds Huge Nuclear Fuel Tanks. 
 //   Remove Warehouse, Recycle and Weight Distribution Modules.
 //   Place FTT Parts into suitable Tech Tree locations.
 // ============================================================================
 
-// Wish-List. Options in maybe the settings.cfg or a seperate .cfg file to give the user the ability to remove or not the Warehouse,
+// Wish-List. Options in maybe the settings.cfg or a separate .cfg file to give the user the ability to remove or not the Warehouse,
 //    Recycle and Weight Distribution Modules. Also I have no idea yet how to implement the options into the NEEDS[] section
 
 
@@ -15,7 +15,7 @@
 // ============================================================================
 // Remove Warehouse, Recycle and Weight Distribution Modules
 // ============================================================================
-@PART[*NukeFuelTank,*DepletedFuelTank]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[*NukeFuelTank,*DepletedFuelTank]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	!MODULE[USI_ModuleResourceWarehouse],* {}
 	!MODULE[USI_ModuleRecycleBin],* {}
@@ -25,19 +25,19 @@
 // ============================================================================
 // Create Larger Nuclear Fuel Tanks
 // ============================================================================
-@PART[C3_NukeFuelTank]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[C3_NukeFuelTank]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@category = FuelTank
 	@RESOURCE[EnrichedUranium] {@amount = 300}
 }
 
-@PART[C3_DepletedFuelTank]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[C3_DepletedFuelTank]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@category = FuelTank
 	@RESOURCE[DepletedFuel] {@amount = 0.0}
 }
 
-+PART[C3_NukeFuelTank]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
++PART[C3_NukeFuelTank]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@name = Big_C3_NukeFuelTank
 	@rescaleFactor *= 2.0
@@ -53,7 +53,7 @@
 	}
 }
 
-+PART[C3_NukeFuelTank]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
++PART[C3_NukeFuelTank]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@name = Huge_C3_NukeFuelTank
 	@rescaleFactor *= 4.0
@@ -69,7 +69,7 @@
 	}
 }
 
-+PART[C3_DepletedFuelTank]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
++PART[C3_DepletedFuelTank]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@name = Big_C3_DepletedFuelTank
 	@rescaleFactor *= 2.0
@@ -85,7 +85,7 @@
 	}
 }
 
-+PART[C3_DepletedFuelTank]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
++PART[C3_DepletedFuelTank]:NEEDS[FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@name = Huge_C3_DepletedFuelTank
 	@rescaleFactor *= 4.0
@@ -104,7 +104,7 @@
 // ============================================================================
 // Add Radiation Emitters to all Nuclear Fuel Tanks
 // ============================================================================
-@PART[*C3_NukeFuelTank,*C3_DepletedFuelTank]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault,FeatureRadiation]:AFTER[UmbraSpaceIndustries]
+@PART[*C3_NukeFuelTank,*C3_DepletedFuelTank]:NEEDS[FTT,Kerbalism,ProfileDefault,FeatureRadiation]:AFTER[UmbraSpaceIndustries]
 {
 	MODULE
 	{
@@ -113,17 +113,17 @@
 	}
 }
 
-@PART[C3_DepletedFuelTank,Big_C3_NukeFuelTank]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault,FeatureRadiation]:AFTER[UmbraSpaceIndustries]
+@PART[C3_DepletedFuelTank,Big_C3_NukeFuelTank]:NEEDS[FTT,Kerbalism,ProfileDefault,FeatureRadiation]:AFTER[UmbraSpaceIndustries]
 {
 	@MODULE[Emitter]{@radiation *= 1.5} // 0.0015 rad/h
 }
 
-@PART[Big_C3_DepletedFuelTank,Huge_C3_NukeFuelTank]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault,FeatureRadiation]:AFTER[UmbraSpaceIndustries]
+@PART[Big_C3_DepletedFuelTank,Huge_C3_NukeFuelTank]:NEEDS[FTT,Kerbalism,ProfileDefault,FeatureRadiation]:AFTER[UmbraSpaceIndustries]
 {
 	@MODULE[Emitter]{@radiation *= 2.5} // 0.0025 rad/h
 }
 
-@PART[Huge_C3_DepletedFuelTank]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault,FeatureRadiation]:AFTER[UmbraSpaceIndustries]
+@PART[Huge_C3_DepletedFuelTank]:NEEDS[FTT,Kerbalism,ProfileDefault,FeatureRadiation]:AFTER[UmbraSpaceIndustries]
 {
 	@MODULE[Emitter]{@radiation *= 3.0} // 0.003 rad/h
 }
@@ -131,17 +131,17 @@
 // ============================================================================
 // Move Nuclear Fuel Tanks etc to a more suitable Tech Tree location
 // ============================================================================
-@PART[C3_NukeFuelTank,C3_DepletedFuelTank]:NEEDS[!CommunityTechTree,UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[C3_NukeFuelTank,C3_DepletedFuelTank]:NEEDS[!CommunityTechTree,FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@TechRequired = advFuelSystems
 }
 
-@PART[Big_C3_NukeFuelTank,Big_C3_DepletedFuelTank]:NEEDS[!CommunityTechTree,UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[Big_C3_NukeFuelTank,Big_C3_DepletedFuelTank]:NEEDS[!CommunityTechTree,FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@TechRequired = largeVolumeContainment
 }
 
-@PART[Huge_C3_NukeFuelTank,Huge_C3_DepletedFuelTank]:NEEDS[!CommunityTechTree,UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+@PART[Huge_C3_NukeFuelTank,Huge_C3_DepletedFuelTank]:NEEDS[!CommunityTechTree,FTT,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@TechRequired = highPerformanceFuelSystems
 }

--- a/GameData/Kerbalism/Support/USI/USI_ReactorPack.cfg
+++ b/GameData/Kerbalism/Support/USI/USI_ReactorPack.cfg
@@ -1,7 +1,7 @@
 // ============================================================================
 // USI_ReactorPack.cfg
 // Kerbalism support patch for Umbra Space Industries ReactorPack
-//   Adds Uraninite mining, storage, processing and radiation emmitters.
+//   Adds Uraninite mining, storage, processing and radiation emitters.
 //   Uraninite Centrifuge process to extract Enriched Uranium from Uraninite ore.
 //   Depleted Fuel Breeder Reactor process to extract Enriched Uranium from Depleted Fuel.
 //   Nuclear Reactor process for the reactors.
@@ -9,7 +9,7 @@
 //   Place Reactor Parts into suitable Tech Tree locations.
 // ============================================================================
 
-// Wish-List. Options in maybe the settings.cfg or a seperate .cfg file to give the user the ability to remove or not the
+// Wish-List. Options in maybe the settings.cfg or a separate .cfg file to give the user the ability to remove or not the
 // FieldRepair Modules. Also I have no idea yet how to implement the options into the NEEDS[] section.
 
 
@@ -174,13 +174,19 @@ Profile
 	}
 }
 
+@PART[kerbalism-chemicalplant]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
+{
+	@MODULE[ProcessController]:HAS[#title[Uraninite*]]{@capacity *= 2.0}
+	@MODULE[ProcessController]:HAS[#title[Breeder*]]{@capacity *= 2.0}
+}
+
 @PART[MiniISRU]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@MODULE[ProcessController]:HAS[#title[Uraninite*]]{@capacity *= 3.3}
 	@MODULE[ProcessController]:HAS[#title[Breeder*]]{@capacity *= 3.3}
 }
 
-@PART[ISRU]:NEEDS[Kerbalism&ProfileDefault&UmbraSpaceIndustries]:AFTER[UmbraSpaceIndustries]
+@PART[ISRU]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@MODULE[ProcessController]:HAS[#title[Uraninite*]]{@capacity *= 5.0}
 	@MODULE[ProcessController]:HAS[#title[Breeder*]]{@capacity *= 5.0}
@@ -340,28 +346,28 @@ Profile
 // ============================================================================
 // Pseudo-resources used by Kerbalism support for USI ReactorPack
 // ============================================================================
-RESOURCE_DEFINITION
+RESOURCE_DEFINITION:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]
 {
 	name = _Centrifuge
 	density = 0.0
 	isVisible = false
 }
 
-RESOURCE_DEFINITION
+RESOURCE_DEFINITION:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]
 {
 	name = _Breeder
 	density = 0.0
 	isVisible = false
 }
 
-RESOURCE_DEFINITION
+RESOURCE_DEFINITION:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]
 {
 	name = _Nukereactor
 	density = 0.0
 	isVisible = false
 }
 
-@RESOURCE_DEFINITION[DepletedFuel]
+@RESOURCE_DEFINITION[DepletedFuel]:NEEDS[UmbraSpaceIndustries,Kerbalism,ProfileDefault]:AFTER[UmbraSpaceIndustries]
 {
 	@isTweakable = true
 }


### PR DESCRIPTION
There where spaces in the filenames of some of the support files for USI which stopped the MM cache from being used.
Also added a couple of tweaks to the USI support and added a manufacturer name to the slot upgrade part