### PR TITLE
GPOSpeedFuelPump: quick'n'dirty Shielding fix

### DIFF
--- a/GameData/Kerbalism/Support/GPOSpeedFuelPump.cfg
+++ b/GameData/Kerbalism/Support/GPOSpeedFuelPump.cfg
@@ -1,3 +1,5 @@
+// when GPOSpeedFuelPump is fixed, this patch could be removed.
+// see https://github.com/henrybauer/GPOSpeedPump/issues/2 
 @PART[*]:HAS[@MODULE[Habitat],@MODULE[GPOSpeedPump]]:NEEDS[FeatureHabitat,GPOSpeedFuelPump]:AFTER[Kerbalism]
 {
 	@MODULE[GPOSpeedPump]

--- a/GameData/Kerbalism/Support/GPOSpeedFuelPump.cfg
+++ b/GameData/Kerbalism/Support/GPOSpeedFuelPump.cfg
@@ -1,0 +1,7 @@
+@PART[*]:HAS[@MODULE[Habitat],@MODULE[GPOSpeedPump]]:NEEDS[FeatureHabitat,GPOSpeedFuelPump]:AFTER[Kerbalism]
+{
+	@MODULE[GPOSpeedPump]
+	{
+		%ShieldingFlags = 0
+	}
+}


### PR DESCRIPTION
When this is patched into each part that contains Shielding and MODULE GPOSpeedPump when GPOSpeedFuelPump is found, it stops pumping shielding by default.

ofc a player could change it back ingame, but this would be a quick and dirty fix as long as GPOSpeedFuelPump is not fixed itself.

See
https://github.com/henrybauer/GPOSpeedPump/issues/2