### PR TITLE
Tweak resource storage on pods and greenhouse

### DIFF
--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -584,8 +584,10 @@ PARTUPGRADE
       RESOURCE
       {
         name = Nitrogen
-        amount = 10000
-        maxAmount = 10000
+        amount = #$../CrewCapacity$
+        maxAmount = #$../CrewCapacity$
+        @amount *= 500
+        @maxAmount *= 500
       }
     }
 
@@ -626,7 +628,8 @@ PARTUPGRADE
       {
         name = WasteWater
         amount = 0
-        maxAmount = 5
+        maxAmount = #$../CrewCapacity$
+        @maxAmount *= 5
       }
     }
 
@@ -649,7 +652,8 @@ PARTUPGRADE
       {
         name = Waste
         amount = 0
-        maxAmount = 5
+        maxAmount = #$../CrewCapacity$
+        @maxAmount *= 5
       }
     }
 
@@ -666,6 +670,22 @@ PARTUPGRADE
         type = ProcessController
         id_field = resource
         id_value = _MonopropFuelCell
+      }
+    }
+  }
+}
+
+// boost Mk3 Shuttle cockpit Nitrogen storage
+@PART[mk3Cockpit_Shuttle]:NEEDS[ProfileDefault]:FOR[Kerbalism]
+{
+  @MODULE[Configure]
+  {
+    @SETUP[Pressure?Control]
+    {
+	  @RESOURCE[Nitrogen]
+      {
+        @amount *= 3
+        @maxAmount *= 3
       }
     }
   }

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -1114,7 +1114,7 @@ PARTUPGRADE
 	// CarbonDioxide INPUT_RESOURCE parameters work together and can internally interchange information depending on conditions, see below. 
 	
     crop_resource = Food                // name of resource produced by harvests
-    // Based on design targets from Prototype Lunar Greenhouse (see https://www.ag.arizona.edu/lunargreenhouse/MidReviews.html):
+    // Based on design targets from Prototype Lunar Greenhouse (see https://www.ag.arizona.edu/lunargreenhouse/MidReviews.htm ):
     // Design targets are on slide 18 of https://www.ag.arizona.edu/lunargreenhouse/Documents/2012-07-20_01_Giacomelli.pdf
     // Prototype Lunar Greenhouse geometry can be found on slide 14 of https://www.ag.arizona.edu/lunargreenhouse/Documents/2012-07-20_01_Giacomelli.pdf
     // Much larger design for producing food for 6 people can be found here (values not used): https://www.degruyter.com/downloadpdf/j/opag.2017.2.issue-1/opag-2017-0011/opag-2017-0011.pdf
@@ -1606,7 +1606,7 @@ PARTUPGRADE
     SETUP
     {
       name = Waste Incinerator
-      desc = Produce <b>CarbonDioxide</b> by combustion of <b>Waste</b>. Include a small exhaust turbine generator.
+      desc = Produce <b>CarbonDioxide</b> by combustion of <b>Waste</b> with <b>Oxygen</b>. Includes a small exhaust turbine generator.
       tech = precisionEngineering
 
       MODULE
@@ -1690,7 +1690,7 @@ PARTUPGRADE
     SETUP
     {
       name = Selective Catalytic Oxidation
-      desc = <b>Ammonia</b> and <b>Oxygen</b> react with an hydrotalcite-like catalyst to produce <b>Nitrogen</b> and <b>Water</b>.
+      desc = <b>Ammonia</b> and <b>Oxygen</b> react with a hydrotalcite-like catalyst to produce <b>Nitrogen</b> and <b>Water</b>.
       tech = experimentalScience
 
       MODULE

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -1196,8 +1196,8 @@ PARTUPGRADE
   RESOURCE
   {
     name = Ammonia
-    amount = 4000           // enough for 207 days including reclaimed ammonia from wastes, one crop cycle
-    maxAmount = 4000
+    amount = 7100            // enough for 206.5 days including reclaimed ammonia from wastes, one crop cycle, two greenhouses combined
+    maxAmount = 7100
   }
 
   // CarbonDioxide is provided because humans don't provide enough CO2 for their required food production
@@ -1207,23 +1207,23 @@ PARTUPGRADE
   RESOURCE
   {
     name = CarbonDioxide
-    amount = 23000           // enough for 210 days of CO2 injection (25% of total CO2 required), one crop cycle
-    maxAmount = 23000
+    amount = 67000           // enough for 204.5 days of CO2 injection (25% of total CO2 required), one crop cycle, two greenhouses combined
+    maxAmount = 67000
   }
 
   // To support the pressure control
   RESOURCE
   {
     name = Nitrogen
-    amount = 10000           // enough for 215 days , one crop cycle + 15 days 4 hrs
+    amount = 10000           // enough for 214 days , one crop cycle
     maxAmount = 10000
   }
 
   RESOURCE
   {
     name = Water
-    amount = 240           // enough for 204 days including reclaimed water from wastes and humidity, one crop cycle
-    maxAmount = 240
+    amount = 250             // enough for 205 days including reclaimed water from wastes and humidity, one crop cycle, two greenhouses combined
+    maxAmount = 250
   }
 }
 

--- a/src/UI/Planner.cs
+++ b/src/UI/Planner.cs
@@ -1324,7 +1324,6 @@ namespace KERBALISM
 				{
 					case "ElectricCharge":  // mainly used for Ion Engines
 						Resource("ElectricCharge").Consume(thrust_flow * fuel.ratio, "engines");
-						//var x = fuel.currentRequirement;
 						break;
 					case "LqdHydrogen":     // added for cryotanks and any other supported mod that uses Liquid Hydrogen
 						Resource("LqdHydrogen").Consume(thrust_flow * fuel.ratio, "engines");
@@ -1365,7 +1364,6 @@ namespace KERBALISM
 				{
 					case "ElectricCharge":  // mainly used for Ion RCS
 						Resource("ElectricCharge").Consume(thrust_flow * fuel.ratio, "rcs");
-						//var x = fuel.currentRequirement;
 						break;
 					case "LqdHydrogen":     // added for cryotanks and any other supported mod that uses Liquid Hydrogen
 						Resource("LqdHydrogen").Consume(thrust_flow * fuel.ratio, "rcs");


### PR DESCRIPTION
Nitrogen, Wastewater and Waste storage on crewed pods is calculated by the crew capacity.
Greenhouse resource storage tweaked to work better when two greenhouses are used together to produce one Kerbal's food.
Also has the added benefit of increasing the duration of resupply when a single Greenhouse is used as a scrubber for one Kerbal.