### PR TITLE
Fixed broken text labels in Panel and Ring

### DIFF
--- a/src/Automation/Devices/Panel.cs
+++ b/src/Automation/Devices/Panel.cs
@@ -81,9 +81,9 @@ namespace KERBALISM
 			string state = Lib.Proto.GetString(panel, "deployState");
 			switch (state)
 			{
-				case "EXTENDED": return "<color=cyan>" + Localizer.Format("KERBALISM_Generic_EXTENDED") + "</color>";
-				case "RETRACTED": return "<color=red>" + Localizer.Format("KERBALISM_Generic_RETRACTED") + "</color>";
-				case "BROKEN": return "<color=red>" + Localizer.Format("KERBALISM_Generic_BROKEN") + "</color>";
+				case "EXTENDED": return "<color=cyan>" + Localizer.Format("#KERBALISM_Generic_EXTENDED") + "</color>";
+				case "RETRACTED": return "<color=red>" + Localizer.Format("#KERBALISM_Generic_RETRACTED") + "</color>";
+				case "BROKEN": return "<color=red>" + Localizer.Format("#KERBALISM_Generic_BROKEN") + "</color>";
 			}
 			return "unknown";
 		}

--- a/src/Automation/Devices/Ring.cs
+++ b/src/Automation/Devices/Ring.cs
@@ -27,7 +27,7 @@ namespace KERBALISM
 
 		public override string Info()
 		{
-			return ring.deployed ? "<color=cyan>" + Localizer.Format("#KERBALISM_Generic_DEPLOYED") + "</color>" : "<color=red>" + Localizer.Format("KERBALISM_Generic_RETRACTED") + "</color>";
+			return ring.deployed ? "<color=cyan>" + Localizer.Format("#KERBALISM_Generic_DEPLOYED") + "</color>" : "<color=red>" + Localizer.Format("#KERBALISM_Generic_RETRACTED") + "</color>";
 		}
 
 		public override void Ctrl(bool value)
@@ -68,7 +68,7 @@ namespace KERBALISM
 		public override string Info()
 		{
 			bool deployed = Lib.Proto.GetBool(ring, "deployed");
-			return deployed ? "<color=cyan>" + Localizer.Format("#KERBALISM_Generic_DEPLOYED") + "</color>" : "<color=red>" + Localizer.Format("KERBALISM_Generic_RETRACTED") + "</color>";
+			return deployed ? "<color=cyan>" + Localizer.Format("#KERBALISM_Generic_DEPLOYED") + "</color>" : "<color=red>" + Localizer.Format("#KERBALISM_Generic_RETRACTED") + "</color>";
 		}
 
 		public override void Ctrl(bool value)


### PR DESCRIPTION
Found a few calls to `Localizer.Format()` without a `#` in the lookup key. 