### PR TITLE
Fixed broken low_battery localization.

### DIFF
--- a/GameData/Kerbalism/Localization/de.cfg
+++ b/GameData/Kerbalism/Localization/de.cfg
@@ -246,9 +246,9 @@ Localization
 		#KERBALISM_Science_inoperable = Das Experiment ist jetzt nicht mehr funktionsfähig, das Zurücksetzen erfordert einen <b>Wissenschaftler</b>
 
  		//Profile
-		#KERBALISM_battery_low = Batterien in $VESSEL sind fast leer@<i>Wir quetschen den letzten Rest aus ihnen</i>|$VESSEL Batterien sind fast leer@<i>Schalte alle unnötigen Systeme ab</i>
-		#KERBALISM_battery_empty = $VESSEL hat keinen Strom mehr@<i>Lebenserhaltungssysteme sind ausgefallen</i>|$VESSEL hat keinen Strom mehr@<i>Wir haben die Kontrolle verloren</i>
-		#KERBALISM_battery_refill = $VESSEL Batterien sind wieder aufgeladen@<i>Die Besatzung darf wieder Musik hören</i>|$VESSEL Batterien sind wieder aufgeladen@<i>Systeme sind wieder online</i>
+		#KERBALISM_low_battery = Batterien in $VESSEL sind fast leer@<i>Wir quetschen den letzten Rest aus ihnen</i>|$VESSEL Batterien sind fast leer@<i>Schalte alle unnötigen Systeme ab</i>
+		#KERBALISM_empty_battery = $VESSEL hat keinen Strom mehr@<i>Lebenserhaltungssysteme sind ausgefallen</i>|$VESSEL hat keinen Strom mehr@<i>Wir haben die Kontrolle verloren</i>
+		#KERBALISM_refill_battery = $VESSEL Batterien sind wieder aufgeladen@<i>Die Besatzung darf wieder Musik hören</i>|$VESSEL Batterien sind wieder aufgeladen@<i>Systeme sind wieder online</i>
 
 		#KERBALISM_oxygen_warning = $ON_VESSEL$KERBAL kann nicht mehr atmen
 		#KERBALISM_oxygen_danger = $ON_VESSEL$KERBAL erstickt gerade

--- a/GameData/Kerbalism/Localization/en-us.cfg
+++ b/GameData/Kerbalism/Localization/en-us.cfg
@@ -262,9 +262,9 @@ Localization
 		#KERBALISM_Science_inoperable = The experiment is now inoperable, resetting will require a <b>Scientist</b>
 
 		//Profile
-		#KERBALISM_battery_low = $VESSEL batteries are almost empty@<i>We are squeezing the last bit of juice</i>|$VESSEL batteries are almost empty@<i>Shutting down non-essential systems</i>
-		#KERBALISM_battery_empty = There is no more ElectricCharge on $VESSEL@<i>Life support systems are off</i>|There is no more ElectricCharge on $VESSEL@<i>We lost control</i>
-		#KERBALISM_battery_refill = $VESSEL batteries recharged@<i>The crew is allowed music again</i>|$VESSEL batteries recharged@<i>Systems are back online</i>
+		#KERBALISM_low_battery = $VESSEL batteries are almost empty@<i>We are squeezing the last bit of juice</i>|$VESSEL batteries are almost empty@<i>Shutting down non-essential systems</i>
+		#KERBALISM_empty_battery = There is no more ElectricCharge on $VESSEL@<i>Life support systems are off</i>|There is no more ElectricCharge on $VESSEL@<i>We lost control</i>
+		#KERBALISM_refill_battery = $VESSEL batteries recharged@<i>The crew is allowed music again</i>|$VESSEL batteries recharged@<i>Systems are back online</i>
 
 		#KERBALISM_oxygen_warning = $ON_VESSEL$KERBAL can't breathe
 		#KERBALISM_oxygen_danger = $ON_VESSEL$KERBAL is suffocating

--- a/src/Profile/Rule.cs
+++ b/src/Profile/Rule.cs
@@ -1,5 +1,4 @@
-﻿using KSP.Localization;
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 
@@ -32,10 +31,10 @@ namespace KERBALISM
 			fatal_message = Lib.ConfigValue(node, "fatal_message", string.Empty);
 			relax_message = Lib.ConfigValue(node, "relax_message", string.Empty);
 
- 			if (warning_message.Length > 0 && warning_message[0] == '#') warning_message = Localizer.Format(warning_message);
-                        if (danger_message.Length > 0 && danger_message[0] == '#') danger_message = Localizer.Format(danger_message);
-                        if (fatal_message.Length > 0 && fatal_message[0] == '#') fatal_message = Localizer.Format(fatal_message);
-                        if (relax_message.Length > 0 && relax_message[0] == '#') relax_message = Localizer.Format(relax_message);
+			if (warning_message.Length > 0 && warning_message[0] == '#') Lib.Log("Broken translation: " + warning_message);
+			if (danger_message.Length > 0 && danger_message[0] == '#') Lib.Log("Broken translation: " + danger_message);
+			if (fatal_message.Length > 0 && fatal_message[0] == '#') Lib.Log("Broken translation: " + fatal_message);
+			if (relax_message.Length > 0 && relax_message[0] == '#') Lib.Log("Broken translation: " + relax_message);
 
             // check that name is specified
             if (name.Length == 0) throw new Exception("skipping unnamed rule");

--- a/src/Profile/Supply.cs
+++ b/src/Profile/Supply.cs
@@ -1,5 +1,4 @@
-﻿using KSP.Localization;
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 
@@ -22,9 +21,9 @@ namespace KERBALISM
 			empty_message = Lib.ConfigValue(node, "empty_message", string.Empty);
 			refill_message = Lib.ConfigValue(node, "refill_message", string.Empty);
 
-			if (low_message.Length > 0 && low_message[0] == '#') low_message = Localizer.Format(low_message);
-			if (empty_message.Length > 0 && empty_message[0] == '#') empty_message = Localizer.Format(empty_message);
-			if (refill_message.Length > 0 && refill_message[0] == '#') refill_message = Localizer.Format(refill_message);
+			if (low_message.Length > 0 && low_message[0] == '#') Lib.Log("Broken translation: " + low_message);
+			if (empty_message.Length > 0 && empty_message[0] == '#') Lib.Log("Broken translation: " + empty_message);
+			if (refill_message.Length > 0 && refill_message[0] == '#') Lib.Log("Broken translation: " + refill_message);
 
 			// check that resource is specified
 			if (resource.Length == 0) throw new Exception("skipping resource-less supply");


### PR DESCRIPTION
The localization texts for battery low/empty/refill were broken.

Also added a log message entry if any localization texts from profiles were not found, this should help to avoid such mixups in the future.