### PR TITLE
Balance LF + OX production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Changes since the last release
 
+ * Rebalanced Sabatier and Anthraquinone processes to output LiquidFuel and Oxidizer at Stock ratio of 9:11 (PiezPiedPy) 
  * Rebalanced H2+O2 and LH2+O2 fuel cells to output more realistic EC levels (PiezPiedPy)
  * Some tooltip colors changed from a nasty hard to see red to a nice gold (PiezPiedPy)
  * RemoteTech antennas can now break due to reliability failures (Sir Mortimer [GRUMP])

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -369,25 +369,25 @@ Profile
 
   Process
   {
-    name = sabatier process
+    name = sabatier process   // LiquidFuel output balanced to match Anthraquinone Oxidizer output
     modifier = _Sabatier
-    input = ElectricCharge@0.5
-    input = CarbonDioxide@0.2514920085
-    input = Hydrogen@1.0
-    output = Water@0.0004017039
-    output = LiquidFuel@0.0001788570195417 // (Methane@0.2494519101)
+    input = ElectricCharge@0.002556692 // calculated using 1.03 J/(g K) (sustained heating to 300c)
+    input = CarbonDioxide@3.490273221
+    input = Hydrogen@13.87826691
+    output = Water@0.005574954
+    output = LiquidFuel@0.000496445    // (Methane@3.46196019) Note that LiquidFuel has a density of 5Kg/Unit
     dump = Water
   }
 
   Process
   {
-    name = sabatier process water priority
+    name = sabatier process water priority   // LiquidFuel output balanced to match Anthraquinone Oxidizer output
     modifier = _SabatierH2OPriority
-    input = ElectricCharge@0.5
-    input = CarbonDioxide@0.2514920085
-    input = Hydrogen@1.0
-    output = Water@0.0004017039
-    output = LiquidFuel@0.0001788570195417 // (Methane@0.2494519101)
+    input = ElectricCharge@0.002556692 // calculated using 1.03 J/(g K) (sustained heating to 300c)
+    input = CarbonDioxide@3.490273221
+    input = Hydrogen@13.87826691
+    output = Water@0.005574954
+    output = LiquidFuel@0.000496445    // (Methane@3.46196019) Note that LiquidFuel has a density of 5Kg/Unit
     dump = LiquidFuel
   }
 
@@ -402,11 +402,11 @@ Profile
 
   Process
   {
-    name = anthraquinone process
+    name = anthraquinone process   // Oxidizer output balanced to match Sabatier LiquidFuel output
     modifier = _Anthraquinone
-    input = Hydrogen@1.0
-    input = Oxygen@1.0120677706
-    output = Oxidizer@0.001516915615 // (HydrogenPeroxide@0.0010461487)
+    input = Hydrogen@2.0
+    input = Oxygen@2.0241355411
+    output = Oxidizer@0.0006067662   // (HydrogenPeroxide@0.0020922973) Note that Oxidizer has a density of 5Kg/Unit
   }
 
   Process


### PR DESCRIPTION
Rebalanced Sabatier and Anthraquinone processes to output LiquidFuel and Oxidizer at Stock ratio of 9:11.
Sabatier EC has also been calculated using Specific heat of methane kept at a constant 300c for conversion.