### PR TITLE
Allow group filter to work with multiple words.

### DIFF
--- a/src/UI/Monitor.cs
+++ b/src/UI/Monitor.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine;
-
+using System.Linq;
 
 namespace KERBALISM
 {
@@ -175,6 +175,17 @@ namespace KERBALISM
 			return Math.Min(h, Screen.height * 0.75f);
 		}
 
+		bool Filter_match(String vesselGroup) {
+			List<String> filterTags = filter.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries).Select(p => p.Trim()).ToList();
+			List<String> vesselTags = vesselGroup.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries).Select(p => p.Trim()).ToList();
+			foreach(String tag in filterTags) {
+				if(!vesselTags.Contains(tag)) {
+					return false;
+				}
+			}
+			return true;
+		}
+
 		bool Render_vessel(Panel p, Vessel v)
 		{
 			// get vessel info
@@ -190,7 +201,7 @@ namespace KERBALISM
 			show_filter |= vd.group.Length > 0 && vd.group != "NONE";
 
 			// skip filtered vessels
-			if (Filtered() && vd.group != filter) return false;
+			if (Filtered() && !Filter_match(vd.group)) return false;
 
 			// get resource handler
 			Vessel_resources resources = ResourceCache.Get(v);


### PR DESCRIPTION
Vessel names now can contain mutliple words (separated by blanks or commas),
group filtering will search for all words in the goup name.

Example: suppose you have 4 vessels with the group names
"RELAY KERBIN", "RELAY MUN", "RELAY MINMUS", "MUN STATION"

In the monitor, if you search for...

"RELAY": will show "RELAY KERBIN", "RELAY MUN" and "RELAY MINMUS"
"MUN": will show "RELAY MUN" and "MUN STATION"
"KERBIN": will show "RELAY KERBIN"
"STATION MUN": will show "MUN STATION" (order is not important)