### PR TITLE
Revert GPOSpeedFuelPump: quick'n'dirty Shielding fix #81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Changes since the last release
 
+ * Reverted the Quick'n'dirty fix for GPOSpeedFuelPump because that one is fixed now with v1.8.14 (Gordon Dry)
  * Added a fix to make sure there is a module Reliability for parachutes, also for RealChute/RealChuteFAR (Gordon Dry)
  * Scaled the ISRU's capacity to be more representative of their size (PiezPiedPy)
  * All priority type processes have been removed and replaced with a Dump button that configures the resource type(s)

--- a/GameData/Kerbalism/Support/GPOSpeedFuelPump.cfg
+++ b/GameData/Kerbalism/Support/GPOSpeedFuelPump.cfg
@@ -1,12 +1,5 @@
-// when GPOSpeedFuelPump is fixed, this patch could be removed.
-// see https://github.com/henrybauer/GPOSpeedPump/issues/2 
-@PART[*]:HAS[@MODULE[Habitat],@MODULE[GPOSpeedPump]]:NEEDS[FeatureHabitat,GPOSpeedFuelPump]:AFTER[Kerbalism]
-{
-	@MODULE[GPOSpeedPump]
-	{
-		%ShieldingFlags = 0
-	}
-}
+// use GPOSpeedFuelPump > v1.8.14
+// https://github.com/henrybauer/GPOSpeedPump/releases
 
 // give the supply containers and pressurized tanks GPOSpeedFuelPump functionality
 @PART[kerbalism-container-inline-*,kerbalism-container-radial-*]:HAS[!MODULE[GPOSpeedPump]]:NEEDS[ProfileDefault,GPOSpeedFuelPump]:AFTER[Kerbalism]


### PR DESCRIPTION
Revert
https://github.com/steamp0rt/Kerbalism/pull/81/commits/0c6c260173cd69f36398818b3303015d430a08da
because of
https://github.com/henrybauer/GPOSpeedPump/releases/tag/v1.8.14