### PR TITLE
RemoteTech EnergyCost is too low, just made it 10x

### DIFF
--- a/GameData/Kerbalism/Support/RemoteTech.cfg
+++ b/GameData/Kerbalism/Support/RemoteTech.cfg
@@ -275,7 +275,7 @@
 {
 	@MODULE[ModuleRTAntenna]:HAS[~DishAngle[],#Mode1OmniRange[>0]] // omni
 	{
-		@EnergyCost /= 1000
+		@EnergyCost /= 100
 		@TRANSMITTER
 		{
 			@PacketResourceCost /= 1000
@@ -287,7 +287,7 @@
 {
 	@MODULE[ModuleRTAntenna]:HAS[#DishAngle[>0],#Mode1DishRange[>0]] // dish
 	{
-		@EnergyCost /= 500
+		@EnergyCost /= 50
 		@TRANSMITTER
 		{
 			@PacketResourceCost /= 500


### PR DESCRIPTION
If an (non passive) antenna is using 0.03 W/s on idle it's a little too less, imho.
Now it will be 0.3 W/s.