### PR TITLE
Kerbalism.version change script for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
   - msbuild $EXTRA Kerbalism.sln /t:Build /p:Configuration=Release
 after_success:
   - export MOD_VERSION=$(cat $TRAVIS_BUILD_DIR/GameData/Kerbalism/Kerbalism.version | jq '.VERSION.MAJOR').$(cat $TRAVIS_BUILD_DIR/GameData/Kerbalism/Kerbalism.version | jq '.VERSION.MINOR').$(cat $TRAVIS_BUILD_DIR/GameData/Kerbalism/Kerbalism.version | jq '.VERSION.PATCH')
+  - bash "$TRAVIS_BUILD_DIR/buildscripts/Travis/avc_version.sh $KSPVER $TRAVIS_BUILD_DIR/GameData/Kerbalism/Kerbalism.version"
   - export KSP_VERSION=$(echo $KSPVER | grep -Po '(1\.\d)')
   - /bin/cp -rf $TRAVIS_BUILD_DIR/src/obj/Release/Kerbalism.dll $TRAVIS_BUILD_DIR/GameData/Kerbalism/Kerbalism.dll
   - rm -rf "$TRAVIS_BUILD_DIR/GameData/Kerbalism/Shaders"

--- a/GameData/Kerbalism/Kerbalism.version
+++ b/GameData/Kerbalism/Kerbalism.version
@@ -1,27 +1,10 @@
 {
   "NAME": "Kerbalism",
   "URL": "http://ksp-avc.cybutek.net/version.php?id=559",
-  "DOWNLOAD": "https://spacedock.info/mod/1749/Kerbalism",
-  "CHANGE_LOG_URL": "https://spacedock.info/mod/1749/Kerbalism",
-  "VERSION": {
-    "MAJOR": 1,
-    "MINOR": 8,
-    "PATCH": 0,
-    "BUILD": 0
-  },
-  "KSP_VERSION": {
-    "MAJOR": 1,
-    "MINOR": 4,
-    "PATCH": 5
-  },
-  "KSP_VERSION_MIN": {
-    "MAJOR": 1,
-    "MINOR": 4,
-    "PATCH": 0
-  },
-  "KSP_VERSION_MAX": {
-    "MAJOR": 1,
-    "MINOR": 4,
-    "PATCH": 4
-  }
+  "DOWNLOAD": "https://spacedock.info/mod/1774/Kerbalism",
+  "CHANGE_LOG_URL": "https://spacedock.info/mod/1774/Kerbalism",
+  "VERSION": {"MAJOR": 1, "MINOR": 8, "PATCH": 0, "BUILD": 0},
+  "KSP_VERSION": {"MAJOR": 1, "MINOR": 4, "PATCH": 5},
+  "KSP_VERSION_MIN": {"MAJOR": 1, "MINOR": 4, "PATCH": 0},
+  "KSP_VERSION_MAX": {"MAJOR": 1, "MINOR": 4, "PATCH": 5}
 }

--- a/buildscripts/Travis/avc_version.sh
+++ b/buildscripts/Travis/avc_version.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# KSP AVC .version file editor [PiezPiedPy]
+
+echo Setting $2 for KSP$1
+
+
+# Split passed version
+[[ $1 =~ (([[:digit:]]+)\.([[:digit:]]+)\.([[:digit:]]+)) ]]
+
+
+
+# Injections for KSP 1.3.1
+if [ ${BASH_REMATCH[3]} = 3 ] 
+then
+
+	sed -i "s/\"KSP_VERSION\": {\"MAJOR\": ., \"MINOR\": ., \"PATCH\": .}/\"KSP_VERSION\": {\"MAJOR\": 1, \"MINOR\": 3, \"PATCH\": 1}/g" $2
+	sed -i "s/\"KSP_VERSION_MIN\": {\"MAJOR\": ., \"MINOR\": ., \"PATCH\": .}/\"KSP_VERSION_MIN\": {\"MAJOR\": 1, \"MINOR\": 3, \"PATCH\": 1}/g" $2
+	sed -i "s/\"KSP_VERSION_MAX\": {\"MAJOR\": ., \"MINOR\": ., \"PATCH\": .}/\"KSP_VERSION_MAX\": {\"MAJOR\": 1, \"MINOR\": 3, \"PATCH\": 1}/g" $2
+
+
+
+# Injections for KSP x.x.x
+else
+
+	sed -i "s/\"KSP_VERSION\": {\"MAJOR\": ., \"MINOR\": ., \"PATCH\": .}/\"KSP_VERSION\": {\"MAJOR\": ${BASH_REMATCH[2]}, \"MINOR\": ${BASH_REMATCH[3]}, \"PATCH\": ${BASH_REMATCH[4]}}/g" $2
+
+	sed -i "s/\"KSP_VERSION_MIN\": {\"MAJOR\": ., \"MINOR\": ., \"PATCH\": .}/\"KSP_VERSION_MIN\": {\"MAJOR\": ${BASH_REMATCH[2]}, \"MINOR\": ${BASH_REMATCH[3]}, \"PATCH\": 0}/g" $2
+
+	sed -i "s/\"KSP_VERSION_MAX\": {\"MAJOR\": ., \"MINOR\": ., \"PATCH\": .}/\"KSP_VERSION_MAX\": {\"MAJOR\": ${BASH_REMATCH[2]}, \"MINOR\": ${BASH_REMATCH[3]}, \"PATCH\": ${BASH_REMATCH[4]}}/g" $2
+
+fi


### PR DESCRIPTION
Auto updates the AVC Kerbalism.version file depending on what KSP version is being built by Travis
* Update Spacedock link in .version file and get it ready for sed.
* Bash script to change .version for specified KSP version.
* Add avc_version.sh script to Travis.