### PR TITLE
Search / Filter improvements for the Monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Stock antennas can now be controlled by automation (Yaar Podshipnik)
 * Devices shown in the device manager are now sorted (Sir Mortimer)
 * Fixed the EC issue when accelerating to extremely fast time warp while a ship is in shadow (Sir Mortimer)
-* Improved vessel search in monitor, now you can search for the name of the central body and the vessel name, too (Sir Mortimer)
+* Iproved vessel searching in monitor: you can search for the name of the central body and the vessel name (Sir Mortimer)
 
 ### Known Issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Stock antennas can now be controlled by automation (Yaar Podshipnik)
 * Devices shown in the device manager are now sorted (Sir Mortimer)
 * Fixed the EC issue when accelerating to extremely fast time warp while a ship is in shadow (Sir Mortimer)
+* Improved vessel search in monitor, now you can search for the name of the central body and the vessel name, too (Sir Mortimer)
 
 ### Known Issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 * Stock antennas can now be controlled by automation (Yaar Podshipnik)
 * Devices shown in the device manager are now sorted (Sir Mortimer)
 * Fixed the EC issue when accelerating to extremely fast time warp while a ship is in shadow (Sir Mortimer)
-* Iproved vessel search in monitor: you can search for the name of the central body and the vessel name (Sir Mortimer)
+* Improved vessel search in monitor: you can search for the name of the central body and the vessel name (Sir Mortimer)
+* Added vessel type icons and filter buttons to include/exclude them in the list. TODO: NEED THE ACUTAL ICONS. HELP, ANYONE? (Sir Mortimer, XXX)
 
 ### Known Issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Stock antennas can now be controlled by automation (Yaar Podshipnik)
 * Devices shown in the device manager are now sorted (Sir Mortimer)
 * Fixed the EC issue when accelerating to extremely fast time warp while a ship is in shadow (Sir Mortimer)
-* Iproved vessel searching in monitor: you can search for the name of the central body and the vessel name (Sir Mortimer)
+* Iproved vessel search in monitor: you can search for the name of the central body and the vessel name (Sir Mortimer)
 
 ### Known Issues
 


### PR DESCRIPTION
The Monitor allows to search for
- Groups (as before)
- Name of the vessel
- Name of central body of the vessel
- Partial words (you don't have to type out minmus all the way to
  the end to find your vessels orbiting it)
- Search is case insensitive now

This could also be a first step towards adding vessel type filter buttons (#186). Now that the filter is always visible in the montior, it would be the ideal place to put those icons: make the vessel type icons aligned bottom left, put the search text input next to it.