### PR TITLE
Use Community Category Kit if it is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fixed the EC issue when accelerating to extremely fast time warp while a ship is in shadow (Sir Mortimer)
 * Improved vessel search in monitor: you can search for the name of the central body and the vessel name (Sir Mortimer)
 * Added vessel type icons and filter buttons to include/exclude them in the list (Sir Mortimer, PiezPiedPy)
+* If present, use Community Category Kit for Kerbalism parts (Sir Mortimer)
 
 ### Known Issues
 

--- a/GameData/Kerbalism/Support/CCK.cfg
+++ b/GameData/Kerbalism/Support/CCK.cfg
@@ -1,5 +1,6 @@
 // Supply containers:
-@PART[kerbalism-container*]:NEEDS[CommunityCategoryKit]:FINAL { tags = cck-containers }
+@PART[kerbalism-container-radial*]:NEEDS[CommunityCategoryKit]:FINAL { tags = cck-containers }
+@PART[kerbalism-container-inline*]:NEEDS[CommunityCategoryKit]:FINAL { tags = cck-lifesupport }
 @PART[kerbalism-chemicalplant]:NEEDS[CommunityTechTree]:FINAL { tags = cck-utility }
 @PART[kerbalism-activeshield]:NEEDS[CommunityTechTree]:FINAL { tags = cck-utility }
 @PART[kerbalism-*pump*]:NEEDS[CommunityTechTree]:FINAL { tags = cck-utility }

--- a/GameData/Kerbalism/Support/CCK.cfg
+++ b/GameData/Kerbalism/Support/CCK.cfg
@@ -1,36 +1,17 @@
+// ----------------------------------------------------------------------------
+// pressurized containers appear in life support and in containers
+// ----------------------------------------------------------------------------
 @PART[kerbalism-container-radial*]:NEEDS[CommunityCategoryKit]:AFTER[zzzKerbalism] {
 	%tags = #$tags$ cck-containers cck-lifesupport
 	category = none
 }
 
+// ----------------------------------------------------------------------------
+// Parts that appear in life support only
+// ----------------------------------------------------------------------------
 @PART[kerbalism-container-inline*]:NEEDS[CommunityCategoryKit]:AFTER[zzzKerbalism] {
 	%tags = #$tags$ cck-lifesupport
 	category = none
-}
-
-@PART[kerbalism-chemicalplant]:NEEDS[CommunityTechTree]:AFTER[zzzKerbalism] {
-	%tags = #$tags$ cck-utility
-	category = Utility
-}
-
-@PART[kerbalism-activeshield]:NEEDS[CommunityTechTree]:AFTER[zzzKerbalism] {
-	%tags = #$tags$ cck-utility
-	category = Utility
-}
-
-@PART[kerbalism-*pump*]:NEEDS[CommunityTechTree]:AFTER[zzzKerbalism] {
-	%tags = #$tags$ cck-utility
-	category = Utility
-}
-
-@PART[kerbalism-*antenna*]:NEEDS[CommunityTechTree]:AFTER[zzzKerbalism] {
-	%tags = #$tags$ cck-communication
-	category = Communication
-}
-
-@PART[kerbalism-geigercounter]:NEEDS[CommunityTechTree]:AFTER[zzzKerbalism] {
-	%tags = #$tags$ cck-communication
-	category = Science
 }
 
 @PART[kerbalism-greenhouse|kerbalism-lifesupport*]:NEEDS[CommunityCategoryKit]:AFTER[zzzKerbalism] {
@@ -43,3 +24,9 @@
 	category = none
 }
 
+// ----------------------------------------------------------------------------
+// Remove all parts from the _kerbalism category, removes it from the editors
+// ----------------------------------------------------------------------------
+@PART[kerbalism-*]:NEEDS[CommunityCategoryKit]:AFTER[zzzKerbalism] {
+	@tags ^= :_kerbalism::
+}

--- a/GameData/Kerbalism/Support/CCK.cfg
+++ b/GameData/Kerbalism/Support/CCK.cfg
@@ -1,5 +1,5 @@
 // Supply containers:
-@PART[kerbalism-container-radial*]:NEEDS[CommunityCategoryKit]:FINAL { tags = cck-containers }
+@PART[kerbalism-container-radial*]:NEEDS[CommunityCategoryKit]:FINAL { tags = cck-containers cck-lifesupport }
 @PART[kerbalism-container-inline*]:NEEDS[CommunityCategoryKit]:FINAL { tags = cck-lifesupport }
 @PART[kerbalism-chemicalplant]:NEEDS[CommunityTechTree]:FINAL { tags = cck-utility }
 @PART[kerbalism-activeshield]:NEEDS[CommunityTechTree]:FINAL { tags = cck-utility }

--- a/GameData/Kerbalism/Support/CCK.cfg
+++ b/GameData/Kerbalism/Support/CCK.cfg
@@ -1,24 +1,45 @@
-// Supply containers:
-@PART[kerbalism-container-radial*]:NEEDS[CommunityCategoryKit]:FINAL { tags = cck-containers cck-lifesupport }
-@PART[kerbalism-container-inline*]:NEEDS[CommunityCategoryKit]:FINAL { tags = cck-lifesupport }
-@PART[kerbalism-chemicalplant]:NEEDS[CommunityTechTree]:FINAL { tags = cck-utility }
-
-@PART[kerbalism-activeshield]:NEEDS[CommunityTechTree]:FINAL {
-	tags = cck-utility
+@PART[kerbalism-container-radial*]:NEEDS[CommunityCategoryKit]:AFTER[zzzKerbalism] {
+	%tags = #$tags$ cck-containers cck-lifesupport
 	category = none
 }
 
-@PART[kerbalism-*pump*]:NEEDS[CommunityTechTree]:FINAL { tags = cck-utility }
-@PART[kerbalism-*antenna*]:NEEDS[CommunityTechTree]:FINAL { tags = cck-communication }
-@PART[kerbalism-geigercounter]:NEEDS[CommunityTechTree]:FINAL { tags = cck-communication }
-
-@PART[kerbalism-greenhouse|kerbalism-lifesupport*]:NEEDS[CommunityCategoryKit]:FINAL {
-	tags = cck-lifesupport
+@PART[kerbalism-container-inline*]:NEEDS[CommunityCategoryKit]:AFTER[zzzKerbalism] {
+	%tags = #$tags$ cck-lifesupport
 	category = none
 }
 
-@PART:HAS[@MODULE[GravityRing]]:NEEDS[CommunityCategoryKit]:FINAL {
-	tags = cck-lifesupport
+@PART[kerbalism-chemicalplant]:NEEDS[CommunityTechTree]:AFTER[zzzKerbalism] {
+	%tags = #$tags$ cck-utility
+	category = Utility
+}
+
+@PART[kerbalism-activeshield]:NEEDS[CommunityTechTree]:AFTER[zzzKerbalism] {
+	%tags = #$tags$ cck-utility
+	category = Utility
+}
+
+@PART[kerbalism-*pump*]:NEEDS[CommunityTechTree]:AFTER[zzzKerbalism] {
+	%tags = #$tags$ cck-utility
+	category = Utility
+}
+
+@PART[kerbalism-*antenna*]:NEEDS[CommunityTechTree]:AFTER[zzzKerbalism] {
+	%tags = #$tags$ cck-communication
+	category = Communication
+}
+
+@PART[kerbalism-geigercounter]:NEEDS[CommunityTechTree]:AFTER[zzzKerbalism] {
+	%tags = #$tags$ cck-communication
+	category = Science
+}
+
+@PART[kerbalism-greenhouse|kerbalism-lifesupport*]:NEEDS[CommunityCategoryKit]:AFTER[zzzKerbalism] {
+	%tags = #$tags$ cck-lifesupport
+	category = none
+}
+
+@PART:HAS[@MODULE[GravityRing]]:NEEDS[CommunityCategoryKit]:AFTER[zzzKerbalism] {
+	%tags = #$tags$ cck-lifesupport
 	category = none
 }
 

--- a/GameData/Kerbalism/Support/CCK.cfg
+++ b/GameData/Kerbalism/Support/CCK.cfg
@@ -1,0 +1,10 @@
+// Supply containers:
+@PART[kerbalism-container*]:NEEDS[CommunityCategoryKit]:FINAL { tags = cck-containers }
+@PART[kerbalism-chemicalplant]:NEEDS[CommunityTechTree]:FINAL { tags = cck-utility }
+@PART[kerbalism-activeshield]:NEEDS[CommunityTechTree]:FINAL { tags = cck-utility }
+@PART[kerbalism-*pump*]:NEEDS[CommunityTechTree]:FINAL { tags = cck-utility }
+@PART[kerbalism-*antenna*]:NEEDS[CommunityTechTree]:FINAL { tags = cck-communication }
+@PART[kerbalism-geigercounter]:NEEDS[CommunityTechTree]:FINAL { tags = cck-communication }
+@PART[kerbalism-greenhouse|kerbalism-lifesupport*]:NEEDS[CommunityCategoryKit]:FINAL { tags = cck-lifesupport }
+@PART:HAS[@MODULE[GravityRing]]:NEEDS[CommunityCategoryKit]:FINAL { tags = cck-lifesupport }
+

--- a/GameData/Kerbalism/Support/CCK.cfg
+++ b/GameData/Kerbalism/Support/CCK.cfg
@@ -2,10 +2,23 @@
 @PART[kerbalism-container-radial*]:NEEDS[CommunityCategoryKit]:FINAL { tags = cck-containers cck-lifesupport }
 @PART[kerbalism-container-inline*]:NEEDS[CommunityCategoryKit]:FINAL { tags = cck-lifesupport }
 @PART[kerbalism-chemicalplant]:NEEDS[CommunityTechTree]:FINAL { tags = cck-utility }
-@PART[kerbalism-activeshield]:NEEDS[CommunityTechTree]:FINAL { tags = cck-utility }
+
+@PART[kerbalism-activeshield]:NEEDS[CommunityTechTree]:FINAL {
+	tags = cck-utility
+	category = none
+}
+
 @PART[kerbalism-*pump*]:NEEDS[CommunityTechTree]:FINAL { tags = cck-utility }
 @PART[kerbalism-*antenna*]:NEEDS[CommunityTechTree]:FINAL { tags = cck-communication }
 @PART[kerbalism-geigercounter]:NEEDS[CommunityTechTree]:FINAL { tags = cck-communication }
-@PART[kerbalism-greenhouse|kerbalism-lifesupport*]:NEEDS[CommunityCategoryKit]:FINAL { tags = cck-lifesupport }
-@PART:HAS[@MODULE[GravityRing]]:NEEDS[CommunityCategoryKit]:FINAL { tags = cck-lifesupport }
+
+@PART[kerbalism-greenhouse|kerbalism-lifesupport*]:NEEDS[CommunityCategoryKit]:FINAL {
+	tags = cck-lifesupport
+	category = none
+}
+
+@PART:HAS[@MODULE[GravityRing]]:NEEDS[CommunityCategoryKit]:FINAL {
+	tags = cck-lifesupport
+	category = none
+}
 


### PR DESCRIPTION
* All kerbalism containers moved to container category
* Greenhouse, ECLSS, Gravity ring moved to life support
* All other parts appear in their respective stock categories only,
  the Kerbalism category is now empty and disappears.