### PR TITLE
Fixed experiment sizes for orbital science

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fixed another icons sometimes not displaying bug (PiezPiedPy) 
 * SSPX 2.5m Greenhouse now producing food at the expected rate. (theJesuit)
 * Fixed issue with CommNet not updating for unloaded vessels (leomike, HaullyGames)
+* Fixed Orbital Science experiments size (Sir Mortimer)
 
 ------------------------------------------------------------------------------------------------------
 

--- a/GameData/Kerbalism/Support/OrbitalScience.cfg
+++ b/GameData/Kerbalism/Support/OrbitalScience.cfg
@@ -1,19 +1,19 @@
 // tweak DMagic Orbital Science experiments data size
 
-@EXPERIMENT_DEFINITION[*]:HAS[#id[magScan]]:NEEDS[DMagicOrbitalScience,FeatureScience]           { @dataScale = 30  }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[rpwsScan]]:NEEDS[DMagicOrbitalScience,FeatureScience]          { @dataScale = 33  }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[scopeScan]]:NEEDS[DMagicOrbitalScience,FeatureScience]         { @dataScale = 90  }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmImagingPlatform]]:NEEDS[DMagicOrbitalScience,FeatureScience] { @dataScale = 135 }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmSIGINT]]:NEEDS[DMagicOrbitalScience,FeatureScience]          { @dataScale = 50  }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmReconScan]]:NEEDS[DMagicOrbitalScience,FeatureScience]       { @dataScale = 38  }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmNAlbedoScan]]:NEEDS[DMagicOrbitalScience,FeatureScience]     { @dataScale = 55  }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmXRayDiffract]]:NEEDS[DMagicOrbitalScience,FeatureScience]    { @dataScale = 45  }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmlaserblastscan]]:NEEDS[DMagicOrbitalScience,FeatureScience]  { @dataScale = 81  }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmSolarParticles]]:NEEDS[DMagicOrbitalScience,FeatureScience]  { @dataScale = 32  }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmSoilMoisture]]:NEEDS[DMagicOrbitalScience,FeatureScience]    { @dataScale = 28  }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmAsteroidScan]]:NEEDS[DMagicOrbitalScience,FeatureScience]    { @dataScale = 75  }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmRadiometerScan]]:NEEDS[DMagicOrbitalScience,FeatureScience]  { @dataScale = 49  }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmseismicHammer]]:NEEDS[DMagicOrbitalScience,FeatureScience]   { @dataScale = 29  }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmbathymetryscan]]:NEEDS[DMagicOrbitalScience,FeatureScience]  { @dataScale = 18  }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[dmbiodrillscan]]:NEEDS[DMagicOrbitalScience,FeatureScience]    { @dataScale = 88  }
-@EXPERIMENT_DEFINITION[*]:HAS[#id[AnomalyScan]]:NEEDS[DMagicOrbitalScience,FeatureScience]       { @dataScale = 42  }
+@EXPERIMENT_DEFINITION:HAS[#id[magScan]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]           { @dataScale = 30  }
+@EXPERIMENT_DEFINITION:HAS[#id[rpwsScan]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]          { @dataScale = 33  }
+@EXPERIMENT_DEFINITION:HAS[#id[scopeScan]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]         { @dataScale = 90  }
+@EXPERIMENT_DEFINITION:HAS[#id[dmImagingPlatform]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism] { @dataScale = 135 }
+@EXPERIMENT_DEFINITION:HAS[#id[dmSIGINT]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]          { @dataScale = 50  }
+@EXPERIMENT_DEFINITION:HAS[#id[dmReconScan]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]       { @dataScale = 38  }
+@EXPERIMENT_DEFINITION:HAS[#id[dmNAlbedoScan]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]     { @dataScale = 55  }
+@EXPERIMENT_DEFINITION:HAS[#id[dmXRayDiffract]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]    { @dataScale = 45  }
+@EXPERIMENT_DEFINITION:HAS[#id[dmlaserblastscan]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]  { @dataScale = 81  }
+@EXPERIMENT_DEFINITION:HAS[#id[dmSolarParticles]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]  { @dataScale = 32  }
+@EXPERIMENT_DEFINITION:HAS[#id[dmSoilMoisture]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]    { @dataScale = 28  }
+@EXPERIMENT_DEFINITION:HAS[#id[dmAsteroidScan]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]    { @dataScale = 75  }
+@EXPERIMENT_DEFINITION:HAS[#id[dmRadiometerScan]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]  { @dataScale = 49  }
+@EXPERIMENT_DEFINITION:HAS[#id[dmseismicHammer]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]   { @dataScale = 29  }
+@EXPERIMENT_DEFINITION:HAS[#id[dmbathymetryscan]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]  { @dataScale = 18  }
+@EXPERIMENT_DEFINITION:HAS[#id[dmbiodrillscan]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]    { @dataScale = 88  }
+@EXPERIMENT_DEFINITION:HAS[#id[AnomalyScan]]:NEEDS[DMagicOrbitalScience,FeatureScience]:FOR[Kerbalism]       { @dataScale = 42  }


### PR DESCRIPTION
Support/OrbitalScience.cfg wasn't working. Also, it missed the FOR[Kerbalism] instruction.