### PR TITLE
Reverting RemoteTech optimization because MM can't understand in this context

### DIFF
--- a/GameData/Kerbalism/Support/RemoteTech.cfg
+++ b/GameData/Kerbalism/Support/RemoteTech.cfg
@@ -117,7 +117,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleRTAntenna],!MODULE[Reliability]:HAS[#type[Antenna]],!MODULE[ModuleCommand],~CrewCapacity[>0]]:NEEDS[FeatureReliability,RemoteTech]:AFTER[RemoteTech]
+@PART[*]:HAS[@MODULE[ModuleRTAntenna],!MODULE[Reliability]:HAS[#type[Antenna]],!MODULE[ModuleCommand],~CrewCapacity[]]:NEEDS[FeatureReliability,RemoteTech]:AFTER[RemoteTech]
 {
 	MODULE
 	{
@@ -132,7 +132,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleRTAntennaPassive],!MODULE[Reliability]:HAS[#type[Antenna]],!MODULE[ModuleCommand],~CrewCapacity[>0]]:NEEDS[FeatureReliability,RemoteTech]:AFTER[RemoteTech]
+@PART[*]:HAS[@MODULE[ModuleRTAntenna],!MODULE[Reliability]:HAS[#type[Antenna]],!MODULE[ModuleCommand],#CrewCapacity[<1]]:NEEDS[FeatureReliability,RemoteTech]:AFTER[RemoteTech]
 {
 	MODULE
 	{
@@ -147,7 +147,37 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleRTAntenna],!MODULE[Reliability]:HAS[#type[Antenna]],@MODULE[ModuleCommand],~CrewCapacity[>0]]:NEEDS[FeatureReliability,RemoteTech]:AFTER[RemoteTech]
+@PART[*]:HAS[@MODULE[ModuleRTAntennaPassive],!MODULE[Reliability]:HAS[#type[Antenna]],!MODULE[ModuleCommand],~CrewCapacity[]]:NEEDS[FeatureReliability,RemoteTech]:AFTER[RemoteTech]
+{
+	MODULE
+	{
+		name = Reliability
+		type = Antenna
+		title = Antenna
+		redundancy = Communication
+		repair = Engineer
+		mtbf = 72576000 // 8y
+		extra_cost = 1.0
+		extra_mass = 0.1
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleRTAntennaPassive],!MODULE[Reliability]:HAS[#type[Antenna]],!MODULE[ModuleCommand],#CrewCapacity[<1]]:NEEDS[FeatureReliability,RemoteTech]:AFTER[RemoteTech]
+{
+	MODULE
+	{
+		name = Reliability
+		type = Antenna
+		title = Antenna
+		redundancy = Communication
+		repair = Engineer
+		mtbf = 72576000 // 8y
+		extra_cost = 1.0
+		extra_mass = 0.1
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleRTAntenna],!MODULE[Reliability]:HAS[#type[Antenna]],@MODULE[ModuleCommand],~CrewCapacity[]]:NEEDS[FeatureReliability,RemoteTech]:AFTER[RemoteTech]
 {
 	MODULE
 	{
@@ -162,7 +192,37 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleRTAntennaPassive],!MODULE[Reliability]:HAS[#type[Antenna]],@MODULE[ModuleCommand],~CrewCapacity[>0]]:NEEDS[FeatureReliability,RemoteTech]:AFTER[RemoteTech]
+@PART[*]:HAS[@MODULE[ModuleRTAntenna],!MODULE[Reliability]:HAS[#type[Antenna]],@MODULE[ModuleCommand],#CrewCapacity[<1]]:NEEDS[FeatureReliability,RemoteTech]:AFTER[RemoteTech]
+{
+	MODULE
+	{
+		name = Reliability
+		type = Antenna
+		title = Antenna
+		redundancy = Communication
+		repair = Engineer
+		mtbf = 72576000 // 8y
+		extra_cost = 0.5
+		extra_mass = 0.01
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleRTAntennaPassive],!MODULE[Reliability]:HAS[#type[Antenna]],@MODULE[ModuleCommand],~CrewCapacity[]]:NEEDS[FeatureReliability,RemoteTech]:AFTER[RemoteTech]
+{
+	MODULE
+	{
+		name = Reliability
+		type = Antenna
+		title = Antenna
+		redundancy = Communication
+		repair = Engineer
+		mtbf = 72576000 // 8y
+		extra_cost = 0.5
+		extra_mass = 0.01
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleRTAntennaPassive],!MODULE[Reliability]:HAS[#type[Antenna]],@MODULE[ModuleCommand],#CrewCapacity[<1]]:NEEDS[FeatureReliability,RemoteTech]:AFTER[RemoteTech]
 {
 	MODULE
 	{


### PR DESCRIPTION
Unfortunately MM is not capable of understanding this in this context.

~CrewCapacity[>0] does not work

So back to one block for
~CrewCapacity[]
and one block for
#CrewCapacity[<1]