### PR TITLE
Just make it equal to the patching of stock Commnet

### DIFF
--- a/GameData/Kerbalism/Support/RemoteTech.cfg
+++ b/GameData/Kerbalism/Support/RemoteTech.cfg
@@ -290,9 +290,41 @@
 
 @PART[*]:HAS[@MODULE[ModuleRTAntenna]]:NEEDS[RemoteTech]:AFTER[RemoteTech]
 {
+	@MODULE[ModuleRTAntenna]:HAS[~DishAngle[],#Mode1OmniRange[>0]] // omni
+	{
+		@TRANSMITTER
+		{
+			@PacketResourceCost /= 1000
+		}
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleRTAntenna]]:NEEDS[RemoteTech]:AFTER[RemoteTech]
+{
+	@MODULE[ModuleRTAntenna]:HAS[#DishAngle[>0],#Mode1DishRange[>0]] // dish
+	{
+		@TRANSMITTER
+		{
+			@PacketResourceCost /= 500
+		}
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleRTAntenna]]:NEEDS[RemoteTech]:AFTER[RemoteTech]
+{
 	@MODULE[ModuleRTAntenna]
 	{
 		@EnergyCost /= 50
 	}
 }
 
+@PART[*]:HAS[@MODULE[ModuleRTAntennaPassive]]:NEEDS[RemoteTech]:AFTER[RemoteTech]
+{
+	@MODULE[ModuleRTAntennaPassive] // probe core internal antenna
+	{
+		@TRANSMITTER
+		{
+			@PacketResourceCost /= 1000
+		}
+	}
+}


### PR DESCRIPTION
I always wondered what is going on.

Why is not the same kind of patching routine done with the RT antennas as like as the Commnet antennas?