### PR TITLE
Slot PartUpgrade defined by ProfileDefault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix Kerbalism parts search filters and missing tab in the VAB/SPH (PiezPiedPy)
 * Fix processes not calculating capacities correctly (PiezPiedPy)
 * Processes default to a switched on state when added in the VAB/SPH (PiezPiedPy) 
+* Made the PartUpgrade for module slots require ProfileDefault (theJesuit)
 
 ------------------------------------------------------------------------------------------------------
 

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -484,7 +484,7 @@ Profile
 // Add Part Upgrade for upgradeable slots
 // ============================================================================
 
-PARTUPGRADE
+PARTUPGRADE:NEEDS[ProfileDefault]:FOR[Kerbalism]
 {
   name = Upgrade-Slots
   partIcon = kerbalism-chemicalplant


### PR DESCRIPTION
This should allow other profiles to easily define their own (or none) slots Part-Upgrades.