### PR TITLE
Another alteration to the Partmodule Upgrade thing in Default Profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix Kerbalism parts search filters and missing tab in the VAB/SPH (PiezPiedPy)
 * Fix processes not calculating capacities correctly (PiezPiedPy)
 * Processes default to a switched on state when added in the VAB/SPH (PiezPiedPy) 
+* Made the PartUpgrade for module slots require ProfileDefault (theJesuit)
 
 ------------------------------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix processes not calculating capacities correctly (PiezPiedPy)
 * Processes default to a switched on state when added in the VAB/SPH (PiezPiedPy) 
 * Made the PartUpgrade for module slots require ProfileDefault (theJesuit)
+* Took away some of the Partupgrade as I upgraded my MM fu. (theJesuit)
 
 ------------------------------------------------------------------------------------------------------
 

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -484,7 +484,7 @@ Profile
 // Add Part Upgrade for upgradeable slots
 // ============================================================================
 
-PARTUPGRADE:NEEDS[ProfileDefault]:FOR[Kerbalism]
+PARTUPGRADE:NEEDS[ProfileDefault]
 {
   name = Upgrade-Slots
   partIcon = kerbalism-chemicalplant

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -484,7 +484,7 @@ Profile
 // Add Part Upgrade for upgradeable slots
 // ============================================================================
 
-PARTUPGRADE
+PARTUPGRADE:NEEDS[ProfileDefault]:FOR[Kerbalism]
 {
   name = Upgrade-Slots
   partIcon = kerbalism-chemicalplant


### PR DESCRIPTION
Takes out the :FOR[Kerbalism] as the Part Upgrade is not a patch and MM throws a hissy.  Not really, its doing what is the most logical thing for it to do.  This now fixes it.  My MM fu is stronger now.

Still applies the Needs: Defaultprofile.