### PR TITLE
 Update habitats for the new V2 and DLC pods and fix atmosphere leakage process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Correct LH2 storage capacities of the Radial container for AirlineKuisine, CryoTanks and USI (PiezPiedPy)
 * Near Future Electrical tweaks: Uranite drilling, storage and ISRU processing added (PiezPiedPy)
 * Textures Unlimited support (HaullyGames)
+* Update habitats for the new V2 and DLC pods (PiezPiedPy)
 
 ------------------------------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Near Future Electrical tweaks: Uranite drilling, storage and ISRU processing added (PiezPiedPy)
 * Textures Unlimited support (HaullyGames)
 * Update habitats for the new V2 and DLC pods (PiezPiedPy)
+* Recalculated habitat atmosphere leakage, was originally calculated for a Human day which is 4x longer (PiezPiedPy)
 
 ------------------------------------------------------------------------------------------------------
 

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -635,8 +635,8 @@ PARTUPGRADE:NEEDS[ProfileDefault]
         name = Nitrogen
         amount = #$/CrewCapacity$
         maxAmount = #$/CrewCapacity$
-        @amount *= 500
-        @maxAmount *= 500
+        @amount *= 125
+        @maxAmount *= 125
       }
     }
 

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -233,7 +233,8 @@ Profile
     dump = true
   }
 
-  // convention: 1 capacity = enough to compensate for leaks in 70 m^2 surface (a cube of 40 m^3 volume)
+  // convention: 1 capacity = enough to compensate for leaks in 70 m^2 surface area (a cube of 40 m^3 volume, edge length of 3.42 m)
+  // replaces the Atmosphere lost via the atmo leaks process
   Process
   {
     name = pressure control
@@ -243,7 +244,9 @@ Profile
     output = Atmosphere@0.35
   }
 
-  // convention: when pressure control is disable in breathabe atmosphere, air pump will consume only EC and pumping air into the vessel
+  // convention: When the vessel is in a breathable atmosphere, pressure control is automatically disabled and the air pump will pump air
+  // into the vessel to maintain pressurization of any habitable areas, one example is inflating inflatable habitats without using any
+  // N2 when a breathable atmosphere is present.
   Process
   {
     name = air pump
@@ -309,8 +312,8 @@ Profile
   {
     name = atmo leaks
     modifier = surface,non_breathable
-    input = Atmosphere@0.000148
-    // from ISS: 899 m³ volume, 452 m² surface (estimated), 0.227 Kg/day (structural) + 1.543 Kg/day (activities)
+    input = Atmosphere@0.000148  // leakage of Atmosphere (N2) per second for a surface area of 1 m²   
+    // from ISS: 899 m³ volume, 452 m² surface (estimated), 0.227 Kg/day (structural) + 1.543 Kg/day (activities) = 1.77 Kg/day
   }
 
   Process

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -233,14 +233,14 @@ Profile
     dump = true
   }
 
-  // convention: 1 capacity = enough to compensate for leaks in 70 m^2 surface area (a cube of 40 m^3 volume, edge length of 3.42 m)
-  // replaces the Atmosphere lost via the atmo leaks process
+  // convention: 1 capacity = enough to compensate for leaks in 70 m² surface area (a cube of 40 m³ volume, edge length of 3.42 m) per crew member
+  // = 0.00253607340283 to replace the Atmosphere leaked via the atmo leaks process for the above approx needed surface area per crew member
   Process
   {
     name = pressure control
     modifier = _PressureControl,non_breathable
     input = ElectricCharge@0.00858
-    input = Nitrogen@0.35
+    input = Nitrogen@0.35  // Much higher than amount needed for leak control to allow speedier pressurization of low pressure habs and inflatables
     output = Atmosphere@0.35
   }
 
@@ -312,8 +312,11 @@ Profile
   {
     name = atmo leaks
     modifier = surface,non_breathable
-    input = Atmosphere@0.000148  // leakage of Atmosphere (N2) per second for a surface area of 1 m²   
+    input = Atmosphere@0.00003622962004  // leakage of Atmosphere (N2) per second for a surface area of 1 m²   
     // from ISS: 899 m³ volume, 452 m² surface (estimated), 0.227 Kg/day (structural) + 1.543 Kg/day (activities) = 1.77 Kg/day
+    // 1 Kerbin day is 1/4 of a human day so 1.77 / 4 = 0.4425 Kg/day
+    // 0.4425 Kg/day over 452 m² = 0.978982301 (g/m²)/day. Using the density of N2 from CRP we get 1.251 g/KSPunit = 0.782559793 (unit/m²)/day
+    // 0.782559793 (unit/m²)/day divided over 21600 secs = 0.00003622962004	(unit/m²)/sec
   }
 
   Process

--- a/GameData/Kerbalism/System/Habitat.cfg
+++ b/GameData/Kerbalism/System/Habitat.cfg
@@ -23,6 +23,14 @@
 		surface = 2.85
 	}
 }
+@PART[mk1pod_v2]:NEEDS[FeatureHabitat]:AFTER[Kerbalism]
+{
+	@MODULE[Habitat]
+	{
+		volume = 0.63
+		surface = 2.85
+	}
+}
 @PART[Mark1Cockpit]:NEEDS[FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
@@ -63,7 +71,23 @@
 		surface = 9.54
 	}
 }
+@PART[mk1-3pod]:NEEDS[FeatureHabitat]:AFTER[Kerbalism]
+{
+	@MODULE[Habitat]
+	{
+		volume = 4.09
+		surface = 9.54
+	}
+}
 @PART[mk2LanderCabin]:NEEDS[FeatureHabitat]:AFTER[Kerbalism]
+{
+	@MODULE[Habitat]
+	{
+		volume = 4.9
+		surface = 7.85
+	}
+}
+@PART[mk2LanderCabin_v2]:NEEDS[FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{
@@ -135,6 +159,54 @@
 		surface = 43.58
 	}
 }
+
+// ============================================================================
+// Ad-hoc volume/surface for stock making history DLC
+// ============================================================================
+
+@PART[kv1Pod]:NEEDS[FeatureHabitat]:AFTER[Kerbalism]
+{
+	@MODULE[Habitat]
+	{
+		volume = 3.89
+		surface = 7.26
+	}
+}
+@PART[kv2Pod]:NEEDS[FeatureHabitat]:AFTER[Kerbalism]
+{
+	@MODULE[Habitat]
+	{
+		volume = 3.89
+		surface = 7.26
+	}
+}
+@PART[kv3Pod]:NEEDS[FeatureHabitat]:AFTER[Kerbalism]
+{
+	@MODULE[Habitat]
+	{
+		volume = 3.89
+		surface = 7.26
+	}
+}
+@PART[Mk2Pod]:NEEDS[FeatureHabitat]:AFTER[Kerbalism]
+{
+	@MODULE[Habitat]
+	{
+		volume = 3.89
+		surface = 7.26
+	}
+}
+@PART[MEMLander]:NEEDS[FeatureHabitat]:AFTER[Kerbalism]
+{
+	@MODULE[Habitat]
+	{
+		volume = 4.02
+		surface = 7.63
+	}
+}
+// ============================================================================
+// Ad-hoc volume/surface for Kerbalism habitats
+// ============================================================================
 
 @PART[kerbalism-gravityring]:NEEDS[FeatureHabitat]:AFTER[Kerbalism]
 {


### PR DESCRIPTION
* Added habitats for the new V2 and DLC pods.
* Recalculated habitat atmosphere leakage, was originally calculated for a Human day which is 4x longer.