### PR TITLE
Early co2 warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -359,6 +359,8 @@ sysinfo.txt
 
 Kerbalism*.zip
 
+MiniAVC.xml
+
 # KSP DLLs
 KSPAssets.dll
 Assembly-*.dll

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Added an 'EVA's available' indicator to the Planner and Monitor (PiezPiedPy)
 * Optimized Planner: Part 1 - Chill the stuttering in VAB/SPH (PiezPiedPy)
 * Reduced Mass of ECLSS and Chemical Processors from 450kg to 40kg (Sir Mortimer)
+* CO2 poisoning warning message will pop up sooner to give you some time to fix the issue (Sir Mortimer)
 
 ------------------------------------------------------------------------------------------------------
 

--- a/GameData/Kerbalism/Profiles/Default.cfg
+++ b/GameData/Kerbalism/Profiles/Default.cfg
@@ -177,6 +177,7 @@ Profile
     name = co2 poisoning
     degeneration = 0.0005555 // 30 minutes
     modifier = poisoning
+    warning_threshold = 0.23
     warning_message = #KERBALISM_co2_warning
     danger_message = #KERBALISM_co2_danger
     fatal_message = #KERBALISM_co2_fatal


### PR DESCRIPTION
CO2 poisoning happens so fast that you might be in an unrecoverable situation even before you hit the danger threshold, especially on high time warp. Once the co2 level is above 2.5ish% scrubbers won't scrub the co2 in time to stop you from dying. This little fix will give you some more time to react before it is too late.