### PR TITLE
Preemptive maintenance: components can be serviced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 * Optimized Planner: Part 1 - Chill the stuttering in VAB/SPH (PiezPiedPy)
 * Reduced Mass of ECLSS and Chemical Processors from 450kg to 40kg (Sir Mortimer)
 * CO2 poisoning warning message will pop up sooner to give you some time to fix the issue (Sir Mortimer)
+* Preemptive maintenance: if a component is found not to be in very good condition during inspection,
+  it can be serviced to avoid a failure (Sir Mortimer)
 
 ------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Kerbals now can perform preemptive maintenance to avert part failures. First, inspect a component. If it is found to have issues, you can service it. Once serviced, it will be as good as new.
![inspection result](https://user-images.githubusercontent.com/43166475/54439161-8e246000-4738-11e9-9801-6c0d25a3e3ea.png)
![servicing](https://user-images.githubusercontent.com/43166475/54439165-911f5080-4738-11e9-89a6-01f9d5814f88.png)
