### PR TITLE
Fixed emitters in automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * CO2 poisoning warning message will pop up sooner to give you some time to fix the issue (Sir Mortimer)
 * Preemptive maintenance: if a component is found not to be in very good condition during inspection,
   it can be serviced to avoid a failure (Sir Mortimer)
+* Fixed emitters (NERVs, nuclear batteries) cannot be controlled in automation and are hidden there (Sir Mortimer)
 
 ------------------------------------------------------------------------------------------------------
 

--- a/src/Kerbalism/Automation/Devices/Emitter.cs
+++ b/src/Kerbalism/Automation/Devices/Emitter.cs
@@ -32,12 +32,18 @@ namespace KERBALISM
 
 		public override void Ctrl(bool value)
 		{
+			if (!emitter.toggle) return;
 			if (emitter.running != value) emitter.Toggle();
 		}
 
 		public override void Toggle()
 		{
 			Ctrl(!emitter.running);
+		}
+
+		public override bool IsVisible()
+		{
+			return emitter.toggle;
 		}
 
 		Emitter emitter;
@@ -69,12 +75,18 @@ namespace KERBALISM
 
 		public override void Ctrl(bool value)
 		{
+			if (!Lib.Proto.GetBool(emitter, "toggle")) return;
 			Lib.Proto.Set(emitter, "running", value);
 		}
 
 		public override void Toggle()
 		{
 			Ctrl(!Lib.Proto.GetBool(emitter, "running"));
+		}
+
+		public override bool IsVisible()
+		{
+			return Lib.Proto.GetBool(emitter, "toggle");
 		}
 
 		private readonly ProtoPartModuleSnapshot emitter;


### PR DESCRIPTION
The automation UI listed fixed emitters, like the NERV and lied about being able to turn it on or off. Worse than that, when you try to turn it on or off, the Kerbalism UI effectively renders non responsive.

Fixed emitters (they already have the toggle boolean in the config) are no longer listed in automation, and it is no longer possible to "control" (ha ha) them from there.