### PR TITLE
Fixed process running presets in the VAB

### DIFF
--- a/GameData/Kerbalism/System/Sickbay.cfg
+++ b/GameData/Kerbalism/System/Sickbay.cfg
@@ -47,7 +47,7 @@ PARTUPGRADE:NEEDS[FeatureComfort]
   description = Installs a tranquilizing vortex (TV) in all crewed modules with sufficient space.
 }
 
-@PART[Large_Crewed_Lab, crewCabin]:NEEDS[FeatureComfort]:FOR[Kerbalism]
+@PART[Large_Crewed_Lab,crewCabin]:NEEDS[FeatureComfort]:FOR[Kerbalism]
 {
   MODULE {
     name = Sickbay
@@ -133,4 +133,3 @@ PARTUPGRADE:NEEDS[FeatureComfort]
     }
   }
 }
-

--- a/src/Kerbalism/Cache.cs
+++ b/src/Kerbalism/Cache.cs
@@ -9,7 +9,7 @@ namespace KERBALISM
 
 	public sealed class Vessel_info
 	{
-		public Vessel_info(Vessel v, uint vessel_id, UInt64 inc)
+		public Vessel_info(Vessel v, UInt64 vessel_id, UInt64 inc)
 		{
 			// NOTE: anything used here can't in turn use cache, unless you know what you are doing
 
@@ -129,7 +129,7 @@ namespace KERBALISM
 		public bool is_vessel;              // true if this is a valid vessel
 		public bool is_rescue;              // true if this is a rescue mission vessel
 		public bool is_valid;               // equivalent to (is_vessel && !is_rescue && !eva_dead)
-		public UInt32 id;                   // generate the id once
+		public UInt64 id;                   // generate the id once
 		public int crew_count;              // number of crew on the vessel
 		public int crew_capacity;           // crew capacity of the vessel
 		public double sunlight;             // if the vessel is in direct sunlight
@@ -179,7 +179,7 @@ namespace KERBALISM
 	{
 		public static void Init()
 		{
-			vessels = new Dictionary<uint, Vessel_info>();
+			vessels = new Dictionary<UInt64, Vessel_info>();
 			next_inc = 0;
 		}
 
@@ -209,8 +209,8 @@ namespace KERBALISM
 			if (vessels.Count > 0)
 			{
 				UInt64 oldest_inc = UInt64.MaxValue;
-				UInt32 oldest_id = 0;
-				foreach (KeyValuePair<UInt32, Vessel_info> pair in vessels)
+				UInt64 oldest_id = 0;
+				foreach (KeyValuePair<UInt64, Vessel_info> pair in vessels)
 				{
 					if (pair.Value.inc < oldest_inc)
 					{
@@ -226,7 +226,7 @@ namespace KERBALISM
 		public static Vessel_info VesselInfo(Vessel v)
 		{
 			// get vessel id
-			UInt32 id = Lib.VesselID(v);
+			UInt64 id = Lib.VesselID(v);
 
 			// get the info from the cache, if it exist
 			Vessel_info info;
@@ -251,7 +251,7 @@ namespace KERBALISM
 
 
 		// vessel cache
-		static Dictionary<UInt32, Vessel_info> vessels;
+		static Dictionary<UInt64, Vessel_info> vessels;
 
 		// used to generate unique id
 		static UInt64 next_inc;

--- a/src/Kerbalism/Lib.cs
+++ b/src/Kerbalism/Lib.cs
@@ -879,16 +879,21 @@ namespace KERBALISM
 			return true;
 		}
 
-		// return a 32bit id for a vessel
-		public static UInt32 VesselID( Vessel v )
+		public static UInt64 VesselID( Vessel v )
 		{
-			return v.persistentId;
+			// Lesson learned: v.persistendId is not unique. Far from it, in fact.
+			byte[] b = v.id.ToByteArray();
+			UInt64 result = BitConverter.ToUInt64(b, 0);
+			result ^= BitConverter.ToUInt64(b, 8);
+			return result;
 		}
 
-		// return a 32bit id for a vessel
-		public static UInt32 VesselID( ProtoVessel pv )
+		public static UInt64 VesselID( ProtoVessel pv )
 		{
-			return pv.persistentId;
+			byte[] b = pv.vesselID.ToByteArray();
+			UInt64 result = BitConverter.ToUInt64(b, 0);
+			result ^= BitConverter.ToUInt64(b, 8);
+			return result;
 		}
 
 		// return the flight id of the root part of a vessel

--- a/src/Kerbalism/Modules/ProcessController.cs
+++ b/src/Kerbalism/Modules/ProcessController.cs
@@ -18,7 +18,7 @@ namespace KERBALISM
 		// persistence/config
 		// note: the running state doesn't need to be serialized, as it can be deduced from resource flow
 		// but we find useful to set running to true in the cfg node for some processes, and not others
-		[KSPField(isPersistant = true)] private bool running;
+		[KSPField(isPersistant = true)] public bool running;
 
 		// amount of times to multiply capacity, used so configure can have the same process in more than one slot
 		[KSPField(isPersistant = true)] public int multiple = 1;

--- a/src/Kerbalism/System/Kerbalism.cs
+++ b/src/Kerbalism/System/Kerbalism.cs
@@ -138,7 +138,7 @@ namespace KERBALISM
 			//
 			// If the BUG TRIGGERED message is never observed in the wild,
 			// it is safe to remove this chunk of code.
-			Dictionary<UInt32, Vessel> vessels = new Dictionary<uint, Vessel>();
+			Dictionary<UInt64, Vessel> vessels = new Dictionary<UInt64, Vessel>();
 			foreach (Vessel v in FlightGlobals.Vessels)
 			{
 				if(vessels.ContainsKey(Lib.VesselID(v)))
@@ -340,7 +340,7 @@ namespace KERBALISM
 		// store time until last update for unloaded vessels
 		// note: not using reference_wrapper<T> to increase readability
 		sealed class Unloaded_data { public double time; }; //< reference wrapper
-		static Dictionary<UInt32, Unloaded_data> unloaded = new Dictionary<uint, Unloaded_data>();
+		static Dictionary<UInt64, Unloaded_data> unloaded = new Dictionary<UInt64, Unloaded_data>();
 
 		// used to update storm data on one body per step
 		static int storm_index;


### PR DESCRIPTION
Some processes (like scrubbers etc.) are meant to be preset to true in the VAB, #338 broke this. I've made a persisted member variable private in #338, looks like that broke this preset.

I guess somewhere this is being set via reflection, I just can't figure out where. Shouldn't have emptied that big glass of scotch yesterday...