### PR TITLE
Allow Experiments to run without crew + have optional reset requirement

### DIFF
--- a/src/Kerbalism/Modules/Experiment.cs
+++ b/src/Kerbalism/Modules/Experiment.cs
@@ -17,18 +17,23 @@ namespace KERBALISM
 		[KSPField] public double data_rate;           // sampling rate in Mb/s
 		[KSPField] public double ec_rate;             // EC consumption rate per-second
 		[KSPField] public bool transmissible = true;  // true if data can be transmitted
-		[KSPField] public string deploy = string.Empty; // deploy animation
 		[KSPField] public string crew = string.Empty;   // operator crew
+		[KSPField] public string reset = string.Empty;  // reset crew. if set, experiments will stop working on situation change
+
+		// animations
+		[KSPField] public string deploy = string.Empty; // deploy animation
 
 		// persistence
 		[KSPField(isPersistant = true)] public bool recording;
 		[KSPField(isPersistant = true)] public string issue = string.Empty;
+		[KSPField(isPersistant = true)] public string last_subject_id = string.Empty;
 
 		// animations
 		Animator deploy_anim;
 
 		// crew specs
 		CrewSpecs operator_cs;
+		CrewSpecs reset_cs;
 
 		// experiment title
 		string exp_name;
@@ -46,7 +51,10 @@ namespace KERBALISM
 			deploy_anim.Still(recording ? 1.0 : 0.0);
 
 			// parse crew specs
-			operator_cs = new CrewSpecs(crew);
+			if(!string.IsNullOrEmpty(crew))
+				operator_cs = new CrewSpecs(crew);
+			if (!string.IsNullOrEmpty(reset))
+				reset_cs = new CrewSpecs(reset);
 
 			// get experiment title
 			exp_name = ResearchAndDevelopment.GetExperiment(experiment).experimentTitle;
@@ -58,6 +66,9 @@ namespace KERBALISM
 			// in flight
 			if (Lib.IsFlight())
 			{
+				Vessel v = FlightGlobals.ActiveVessel;
+				if (v == null || EVA.IsDead(v)) return;
+
 				// get info from cache
 				Vessel_info vi = Cache.VesselInfo(vessel);
 
@@ -65,14 +76,16 @@ namespace KERBALISM
 				if (!vi.is_valid) return;
 
 				// update ui
-				bool has_operator = operator_cs.Check(vessel);
 				Events["Toggle"].guiName = Lib.StatusToggle(exp_name, !recording ? "stopped" : issue.Length == 0 ? "recording" : Lib.BuildString("<color=#ffff00>", issue, "</color>"));
+				Events["Reset"].guiName = Lib.BuildString("Reset <b>", exp_name, "</b>");
+				Events["Reset"].active = reset_cs != null && reset_cs.Check(v);
 			}
 			// in the editor
 			else if (Lib.IsEditor())
 			{
 				// update ui
 				Events["Toggle"].guiName = Lib.StatusToggle(exp_name, recording ? "recording" : "stopped");
+				Events["Reset"].active = false;
 			}
 		}
 
@@ -93,7 +106,7 @@ namespace KERBALISM
 				// detect conditions
 				// - comparing against amount in previous step
 				bool has_ec = ec.amount > double.Epsilon;
-				bool has_operator = operator_cs.Check(vessel);
+				bool has_operator = operator_cs == null || operator_cs.Check(vessel);
 				string sit = Science.Situation(vessel, situations);
 
 				// deduce issues
@@ -102,21 +115,27 @@ namespace KERBALISM
 				else if (!has_operator) issue = "no operator";
 				else if (!has_ec) issue = "missing <b>EC</b>";
 
-				// if there are no issues
+				string subject_id = string.Empty;
 				if (issue.Length == 0)
 				{
 					// generate subject id
-					string subject_id = Science.Generate_subject(experiment, vessel.mainBody, sit, Science.Biome(vessel, sit), Science.Multiplier(vessel, sit));
+					subject_id = Science.Generate_subject(experiment, vessel.mainBody, sit, Science.Biome(vessel, sit), Science.Multiplier(vessel, sit));
+					bool needsReset = reset_cs != null
+						&& !string.IsNullOrEmpty(last_subject_id) && subject_id != last_subject_id;
+
+					if (needsReset) issue = "reset required";
+				}
+
+				// if there are no issues
+				if (issue.Length == 0)
+				{
+					last_subject_id = subject_id;
 
 					// record in drive
 					if (transmissible)
-					{
-						DB.Vessel(vessel).drive.Record_file(subject_id, data_rate * Kerbalism.elapsed_s);
-					}
+						DB.Vessel(vessel).drive.Record_file(subject_id, data_rate * Kerbalism.elapsed_s, true, true);
 					else
-					{
 						DB.Vessel(vessel).drive.Record_sample(subject_id, data_rate * Kerbalism.elapsed_s);
-					}
 
 					// consume ec
 					ec.Consume(ec_rate * Kerbalism.elapsed_s);
@@ -128,43 +147,76 @@ namespace KERBALISM
 		public static void BackgroundUpdate(Vessel v, ProtoPartModuleSnapshot m, Experiment exp, Resource_info ec, double elapsed_s)
 		{
 			// if experiment is active
-			if (Lib.Proto.GetBool(m, "recording"))
+			if (!Lib.Proto.GetBool(m, "recording"))
+				return;
+
+			// detect conditions
+			// - comparing against amount in previous step
+			bool has_ec = ec.amount > double.Epsilon;
+			bool has_operator = string.IsNullOrEmpty(exp.crew) || new CrewSpecs(exp.crew).Check(v);
+
+			string sit = Science.Situation(v, exp.situations);
+
+			// deduce issues
+			string issue = string.Empty;
+			if (sit.Length == 0) issue = "invalid situation";
+			else if (!has_operator) issue = "no operator";
+			else if (!has_ec) issue = "missing <b>EC</b>";
+
+			string subject_id = string.Empty;
+			if (issue.Length == 0)
 			{
-				// detect conditions
-				// - comparing against amount in previous step
-				bool has_ec = ec.amount > double.Epsilon;
-				bool has_operator = new CrewSpecs(exp.crew).Check(v);
-				string sit = Science.Situation(v, exp.situations);
+				// generate subject id
+				subject_id = Science.Generate_subject(exp.experiment, v.mainBody, sit, Science.Biome(v, sit), Science.Multiplier(v, sit));
+				bool needsReset = !string.IsNullOrEmpty(exp.reset)
+					&& !string.IsNullOrEmpty(exp.last_subject_id) && subject_id != exp.last_subject_id;
 
-				// deduce issues
-				string issue = string.Empty;
-				if (sit.Length == 0) issue = "invalid situation";
-				else if (!has_operator) issue = "no operator";
-				else if (!has_ec) issue = "missing <b>EC</b>";
-				Lib.Proto.Set(m, "issue", issue);
+				if (needsReset) issue = "reset required";
+			}
 
-				// if there are no issues
-				if (issue.Length == 0)
-				{
-					// generate subject id
-					string subject_id = Science.Generate_subject(exp.experiment, v.mainBody, sit, Science.Biome(v, sit), Science.Multiplier(v, sit));
+			Lib.Proto.Set(m, "issue", issue);
 
-					// record in drive
-					if (exp.transmissible)
-					{
-						DB.Vessel(v).drive.Record_file(subject_id, exp.data_rate * elapsed_s);
-					}
-					else
-					{
-						DB.Vessel(v).drive.Record_sample(subject_id, exp.data_rate * elapsed_s);
-					}
+			// if there are no issues
+			if (issue.Length == 0)
+			{
+				Lib.Proto.Set(m, "last_subject_id", subject_id);
 
-					// consume ec
-					ec.Consume(exp.ec_rate * elapsed_s);
-				}
+				// record in drive
+				if (exp.transmissible)
+					DB.Vessel(v).drive.Record_file(subject_id, exp.data_rate * elapsed_s, true, true);
+				else
+					DB.Vessel(v).drive.Record_sample(subject_id, exp.data_rate * elapsed_s);
+
+				// consume ec
+				ec.Consume(exp.ec_rate * elapsed_s);
 			}
 		}
 
+		[KSPEvent(guiActiveUnfocused = true, guiName = "_", active = false)]
+		public void Reset()
+		{
+			// disable for dead eva kerbals
+			Vessel v = FlightGlobals.ActiveVessel;
+			if (v == null || EVA.IsDead(v)) return;
+
+			// check trait
+			if (!reset_cs.Check(v))
+			{
+				Message.Post
+				(
+				  Lib.TextVariant
+				  (
+					"I'm not qualified for this",
+					"I will not even know where to start",
+					"I'm afraid I can't do that"
+				  ),
+				  reset_cs.Warning()
+				);
+				return;
+			}
+
+			last_subject_id = string.Empty;
+		}
 
 		[KSPEvent(guiActive = true, guiActiveEditor = true, guiName = "_", active = true)]
 		public void Toggle()
@@ -199,6 +251,7 @@ namespace KERBALISM
 			specs.Add("Data rate", Lib.HumanReadableDataRate(data_rate));
 			specs.Add("EC required", Lib.HumanReadableRate(ec_rate));
 			if (crew.Length > 0) specs.Add("Operator", new CrewSpecs(crew).Info());
+			if (reset.Length > 0) specs.Add("Reset", new CrewSpecs(reset).Info());
 			specs.Add(string.Empty);
 			specs.Add("<color=#00ffff>Situations:</color>", string.Empty);
 			var tokens = Lib.Tokenize(situations, ',');

--- a/src/Kerbalism/Modules/Experiment.cs
+++ b/src/Kerbalism/Modules/Experiment.cs
@@ -78,7 +78,7 @@ namespace KERBALISM
 				// update ui
 				Events["Toggle"].guiName = Lib.StatusToggle(exp_name, !recording ? "stopped" : issue.Length == 0 ? "recording" : Lib.BuildString("<color=#ffff00>", issue, "</color>"));
 				Events["Reset"].guiName = Lib.BuildString("Reset <b>", exp_name, "</b>");
-				Events["Reset"].active = reset_cs != null && reset_cs.Check(v);
+				Events["Reset"].active = reset_cs != null && reset_cs.Check(v) && !string.IsNullOrEmpty(last_subject_id);
 			}
 			// in the editor
 			else if (Lib.IsEditor())
@@ -195,27 +195,51 @@ namespace KERBALISM
 		[KSPEvent(guiActiveUnfocused = true, guiName = "_", active = false)]
 		public void Reset()
 		{
+			Reset(true);
+		}
+
+		public bool Reset(bool showMessage)
+		{
 			// disable for dead eva kerbals
 			Vessel v = FlightGlobals.ActiveVessel;
-			if (v == null || EVA.IsDead(v)) return;
+			if (v == null || EVA.IsDead(v))
+				return false;
+
+			if (reset_cs == null)
+				return false;
 
 			// check trait
 			if (!reset_cs.Check(v))
 			{
-				Message.Post
-				(
-				  Lib.TextVariant
-				  (
-					"I'm not qualified for this",
-					"I will not even know where to start",
-					"I'm afraid I can't do that"
-				  ),
-				  reset_cs.Warning()
-				);
-				return;
+				if(showMessage)
+				{
+					Message.Post(
+					  Lib.TextVariant
+					  (
+						"I'm not qualified for this",
+						"I will not even know where to start",
+						"I'm afraid I can't do that"
+					  ),
+					  reset_cs.Warning()
+					);
+				}
+				return false;
 			}
 
 			last_subject_id = string.Empty;
+
+			if(showMessage)
+			{
+				Message.Post(
+				  "Reset Done",
+				  Lib.TextVariant
+				  (
+					"It's good to go again",
+					"Ready for the next bit of science"
+				  )
+				);
+			}
+			return true; 
 		}
 
 		[KSPEvent(guiActive = true, guiActiveEditor = true, guiName = "_", active = true)]

--- a/src/Kerbalism/Modules/Laboratory.cs
+++ b/src/Kerbalism/Modules/Laboratory.cs
@@ -178,9 +178,10 @@ namespace KERBALISM
 		[KSPEvent(guiActive = true, guiActiveEditor = false, guiName = "Clean", active = true)]
 		public void CleanExperiments()
 		{
-			List<ModuleScienceExperiment> modules = vessel.FindPartModulesImplementing<ModuleScienceExperiment>();
 			bool message = false;
-			foreach (ModuleScienceExperiment m in modules)
+
+			var stockExperiments = vessel.FindPartModulesImplementing<ModuleScienceExperiment>();
+			foreach (ModuleScienceExperiment m in stockExperiments)
 			{
 				if (m.resettable && m.Inoperable)
 				{
@@ -188,6 +189,14 @@ namespace KERBALISM
 					message = true;
 				}
 			}
+
+			var kerbalismExperiments = vessel.FindPartModulesImplementing<Experiment>();
+			foreach (Experiment m in kerbalismExperiments)
+			{
+				message |= m.Reset(false);
+			}
+
+
 			// inform the user
 			if (message) Message.Post(localized_cleaned);
 		}

--- a/src/Kerbalism/Science/Drive.cs
+++ b/src/Kerbalism/Science/Drive.cs
@@ -63,7 +63,7 @@ namespace KERBALISM
 		}
 
 		// add science data, creating new file or incrementing existing one
-		public void Record_file(string subject_id, double amount, bool allowImmediateTransmission = true)
+		public void Record_file(string subject_id, double amount, bool allowImmediateTransmission = true, bool silentTransmission = false)
 		{
 			// create new data or get existing one
 			File file;
@@ -71,6 +71,7 @@ namespace KERBALISM
 			{
 				file = new File();
 				if (!allowImmediateTransmission) file.send = false;
+				file.silentTransmission = silentTransmission;
 				files.Add(subject_id, file);
 			}
 

--- a/src/Kerbalism/Science/File.cs
+++ b/src/Kerbalism/Science/File.cs
@@ -12,6 +12,7 @@ namespace KERBALISM
 			size = amount;
 			buff = 0.0;
 			send = PreferencesBasic.Instance.transmitScience;
+			silentTransmission = false;
 		}
 
 		public File(ConfigNode node)
@@ -19,6 +20,7 @@ namespace KERBALISM
 			size = Lib.ConfigValue(node, "size", 0.0);
 			buff = Lib.ConfigValue(node, "buff", 0.0);
 			send = Lib.ConfigValue(node, "send", PreferencesBasic.Instance.transmitScience);
+			silentTransmission = Lib.ConfigValue(node, "silentTransmission", false);
 		}
 
 		public void Save(ConfigNode node)
@@ -26,11 +28,13 @@ namespace KERBALISM
 			node.AddValue("size", size);
 			node.AddValue("buff", buff);
 			node.AddValue("send", send);
+			node.AddValue("silentTransmission", silentTransmission);
 		}
 
 		public double size;   // data size in Mb
 		public double buff;   // data transmitted but not credited
-		public bool send;   // send-home flag
+		public bool send;     // send-home flag
+		public bool silentTransmission; // don't show a message when transmitted
 	}
 
 

--- a/src/Kerbalism/Science/Science.cs
+++ b/src/Kerbalism/Science/Science.cs
@@ -84,12 +84,13 @@ namespace KERBALISM
 					// remove the file
 					vd.drive.files.Remove(exp_filename);
 
-					// inform the user
-					Message.Post
-					(
-					  Lib.BuildString("<color=cyan><b>DATA RECEIVED</b></color>\nTransmission of <b>", Experiment(exp_filename).name, "</b> completed"),
-					  Lib.TextVariant("Our researchers will jump on it right now", "The checksum is correct, data must be valid")
-					);
+					if (!file.silentTransmission)
+					{
+						// inform the user
+						Message.Post(
+						  Lib.BuildString("<color=cyan><b>DATA RECEIVED</b></color>\nTransmission of <b>", Experiment(exp_filename).name, "</b> completed"),
+						  Lib.TextVariant("Our researchers will jump on it right now", "The checksum is correct, data must be valid"));
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Experiments are waay too cool to be overlooked any longer.

What they do, in a nutshell: instead of returning the entire science value for an experiment instantly, you have to keep the experiment running for some time (seconds, days, years) to get the full science value. The experiment will keep generating data during all that time, which you then have to get/transmit back to kerbin.

I see a bright future for this part module...
![Test](https://user-images.githubusercontent.com/43166475/55012563-e59fb700-4fe7-11e9-825a-cc6264fdd864.gif)

